### PR TITLE
[JBWS-4068] Upgrade Apache CXF XJC plugins to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <ejb.api.version>1.0.2.Final</ejb.api.version>
     <cxf.version>3.2.0-SNAPSHOT</cxf.version>
     <cxf.asm.version>3.3.1</cxf.asm.version>
-    <cxf.xjcplugins.version>3.0.5</cxf.xjcplugins.version>
+    <cxf.xjcplugins.version>3.1.0</cxf.xjcplugins.version>
     <jboss-logging.version>3.2.1.Final</jboss-logging.version>
     <jboss-logging-annotations.version>1.2.0.Final</jboss-logging-annotations.version>
     <jboss-logging-processor.version>1.2.0.Final</jboss-logging-processor.version>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4068
Updating org.apache.cxf.xjcplugins:* artifacts on master, backporting to 5.1.x-fixes left to your consideration @asoldano 