### PR TITLE
[JBWS-4035] Removed instrumentationManagerImpl.register() as its deprecated

### DIFF
--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/configuration/BusHolder.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/configuration/BusHolder.java
@@ -398,8 +398,8 @@ public class BusHolder
             InstrumentationManagerExtImpl instrumentationManagerImpl = new InstrumentationManagerExtImpl();
             instrumentationManagerImpl.setBus(bus);
             instrumentationManagerImpl.setEnabled(true);
-            instrumentationManagerImpl.initMBeanServer();
-            instrumentationManagerImpl.register();
+            instrumentationManagerImpl.init();
+            instrumentationManagerImpl.initMBeanServer();            
             bus.setExtension(instrumentationManagerImpl, InstrumentationManager.class);
             CounterRepository couterRepository = new CounterRepository();
             couterRepository.setBus(bus);


### PR DESCRIPTION
Removed deprecation method which was showing a WARN message building up the JBWS code. 