### PR TITLE
JBWS-4077: allow configuration of CXF fault interceptors as JBossWS properties

### DIFF
--- a/modules/client/src/main/java/org/jboss/wsf/stack/cxf/client/Constants.java
+++ b/modules/client/src/main/java/org/jboss/wsf/stack/cxf/client/Constants.java
@@ -41,6 +41,8 @@ public class Constants
    public static final String CXF_POLICY_ALTERNATIVE_SELECTOR_PROP = "cxf.policy.alternativeSelector";
    public static final String CXF_IN_INTERCEPTORS_PROP = "cxf.interceptors.in";
    public static final String CXF_OUT_INTERCEPTORS_PROP = "cxf.interceptors.out";
+   public static final String CXF_IN_FAULT_INTERCEPTORS_PROP = "cxf.interceptors.infault";
+   public static final String CXF_OUT_FAULT_INTERCEPTORS_PROP = "cxf.interceptors.outfault";
    public static final String CXF_FEATURES_PROP = "cxf.features";
    public static final String CXF_MANAGEMENT_ENABLED = "cxf.management.enabled";
    public static final String CXF_MANAGEMENT_INSTALL_RESPONSE_TIME_INTERCEPTORS = "cxf.management.installResponseTimeInterceptors";

--- a/modules/client/src/main/java/org/jboss/wsf/stack/cxf/client/configuration/CXFClientConfigurer.java
+++ b/modules/client/src/main/java/org/jboss/wsf/stack/cxf/client/configuration/CXFClientConfigurer.java
@@ -103,6 +103,10 @@ public class CXFClientConfigurer extends ConfigHelper
                InterceptorUtils.removeInterceptors(client.getInInterceptors(), (String)ep.get(p));
             } else if (Constants.CXF_OUT_INTERCEPTORS_PROP.equals(p)) {
                InterceptorUtils.removeInterceptors(client.getOutInterceptors(), (String)ep.get(p));
+            } else if (Constants.CXF_IN_FAULT_INTERCEPTORS_PROP.equals(p)) {
+               InterceptorUtils.removeInterceptors(client.getInFaultInterceptors(), (String)ep.get(p));
+            } else if (Constants.CXF_OUT_FAULT_INTERCEPTORS_PROP.equals(p)) {
+               InterceptorUtils.removeInterceptors(client.getOutFaultInterceptors(), (String)ep.get(p));
             } else if (Constants.CXF_FEATURES_PROP.equals(p)) {
                Loggers.ROOT_LOGGER.couldNoRemoveFeaturesOnClient((String)ep.get(p));
             }

--- a/modules/client/src/main/java/org/jboss/wsf/stack/cxf/client/configuration/InterceptorUtils.java
+++ b/modules/client/src/main/java/org/jboss/wsf/stack/cxf/client/configuration/InterceptorUtils.java
@@ -57,6 +57,20 @@ public class InterceptorUtils
          }
          interceptorProvider.getOutInterceptors().addAll(createInterceptors(outInterceptors, converter));
       }
+      final String inFaultInterceptors = properties.get(Constants.CXF_IN_FAULT_INTERCEPTORS_PROP);
+      if (inFaultInterceptors != null) {
+         if (converter == null) {
+            converter = new MapToBeanConverter(properties);
+         }
+         interceptorProvider.getInFaultInterceptors().addAll(createInterceptors(inFaultInterceptors, converter));
+      }
+      final String outFaultInterceptors = properties.get(Constants.CXF_OUT_FAULT_INTERCEPTORS_PROP);
+      if (outFaultInterceptors != null) {
+         if (converter == null) {
+            converter = new MapToBeanConverter(properties);
+         }
+         interceptorProvider.getOutFaultInterceptors().addAll(createInterceptors(outFaultInterceptors, converter));
+      }
    }
    
    public static void removeInterceptors(List<Interceptor<?>> interceptorsList, String interceptors) {

--- a/modules/client/src/test/java/org/jboss/wsf/stack/cxf/client/configuration/CXFClientConfigurerTest.java
+++ b/modules/client/src/test/java/org/jboss/wsf/stack/cxf/client/configuration/CXFClientConfigurerTest.java
@@ -167,6 +167,8 @@ public class CXFClientConfigurerTest
          Map<String, String> properties = new HashMap<String, String>();
          properties.put(Constants.CXF_IN_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorA org.jboss.wsf.stack.cxf.client.configuration.InterceptorB");
          properties.put(Constants.CXF_OUT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorC,org.jboss.wsf.stack.cxf.client.configuration.InterceptorD");
+         properties.put(Constants.CXF_IN_FAULT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorE,org.jboss.wsf.stack.cxf.client.configuration.InterceptorF");
+         properties.put(Constants.CXF_OUT_FAULT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorG org.jboss.wsf.stack.cxf.client.configuration.InterceptorH");
          
          InterceptorUtils.addInterceptors(client, properties);
          
@@ -175,16 +177,44 @@ public class CXFClientConfigurerTest
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
          interceptors = toNameList(client.getOutInterceptors());
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         interceptors = toNameList(client.getInFaultInterceptors());
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         interceptors = toNameList(client.getOutFaultInterceptors());
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
          
          
          properties = new HashMap<String, String>();
          properties.put(Constants.CXF_IN_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorD, FooInterceptor");
          properties.put(Constants.CXF_OUT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorB");
+         properties.put(Constants.CXF_IN_FAULT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorA, BarInterceptor");
+         properties.put(Constants.CXF_OUT_FAULT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorC");
          
          InterceptorUtils.addInterceptors(client, properties);
          
@@ -193,12 +223,39 @@ public class CXFClientConfigurerTest
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
          assertFalse(interceptors.contains("FooInterceptor"));
          interceptors = toNameList(client.getOutInterceptors());
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         interceptors = toNameList(client.getInFaultInterceptors());
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         assertFalse(interceptors.contains("BarInterceptor"));
+         interceptors = toNameList(client.getOutFaultInterceptors());
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
       } finally {
          if (bus != null) {
             bus.shutdown(true);
@@ -224,6 +281,8 @@ public class CXFClientConfigurerTest
          properties.put("C", "3");
          properties.put(Constants.CXF_IN_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorA org.jboss.wsf.stack.cxf.client.configuration.InterceptorB");
          properties.put(Constants.CXF_OUT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorC,org.jboss.wsf.stack.cxf.client.configuration.InterceptorD");
+         properties.put(Constants.CXF_IN_FAULT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorE,org.jboss.wsf.stack.cxf.client.configuration.InterceptorF");
+         properties.put(Constants.CXF_OUT_FAULT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorG org.jboss.wsf.stack.cxf.client.configuration.InterceptorH");
          
          CXFClientConfigurer cfg = new CXFClientConfigurer();
          
@@ -237,16 +296,44 @@ public class CXFClientConfigurerTest
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
          interceptors = toNameList(client.getOutInterceptors());
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         interceptors = toNameList(client.getInFaultInterceptors());
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         interceptors = toNameList(client.getOutFaultInterceptors());
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
          
          
          properties = new HashMap<String, String>();
          properties.put(Constants.CXF_IN_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorD, FooInterceptor");
          properties.put(Constants.CXF_OUT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorB");
+         properties.put(Constants.CXF_IN_FAULT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorA, BarInterceptor");
+         properties.put(Constants.CXF_OUT_FAULT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorC");
          
          InterceptorUtils.addInterceptors(client, properties);
          
@@ -258,12 +345,39 @@ public class CXFClientConfigurerTest
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
          assertFalse(interceptors.contains("FooInterceptor"));
          interceptors = toNameList(client.getOutInterceptors());
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         interceptors = toNameList(client.getInFaultInterceptors());
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         assertFalse(interceptors.contains("BarInterceptor"));
+         interceptors = toNameList(client.getOutFaultInterceptors());
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
       } finally {
          if (bus != null) {
             bus.shutdown(true);
@@ -289,6 +403,8 @@ public class CXFClientConfigurerTest
          properties.put("C", "3");
          properties.put(Constants.CXF_IN_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorA org.jboss.wsf.stack.cxf.client.configuration.InterceptorB");
          properties.put(Constants.CXF_OUT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorC,org.jboss.wsf.stack.cxf.client.configuration.InterceptorD");
+         properties.put(Constants.CXF_IN_FAULT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorE,org.jboss.wsf.stack.cxf.client.configuration.InterceptorF");
+         properties.put(Constants.CXF_OUT_FAULT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorG org.jboss.wsf.stack.cxf.client.configuration.InterceptorH");
          ClientConfig clientConfig = new ClientConfig("Foo", null, null, properties, null);
          
          CXFClientConfigurer cfg = new CXFClientConfigurer();
@@ -303,14 +419,41 @@ public class CXFClientConfigurerTest
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
          interceptors = toNameList(client.getOutInterceptors());
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         interceptors = toNameList(client.getInFaultInterceptors());
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         interceptors = toNameList(client.getOutFaultInterceptors());
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
          
          
          ClientProxy.getClient(port).getInInterceptors().add(new InterceptorZ());
+         ClientProxy.getClient(port).getInFaultInterceptors().add(new InterceptorY());
          
          properties = new HashMap<String, String>();
          properties.put("E", "10");
@@ -318,6 +461,8 @@ public class CXFClientConfigurerTest
          properties.put("G", "30");
          properties.put(Constants.CXF_IN_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorD, FooInterceptor");
          properties.put(Constants.CXF_OUT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorB");
+         properties.put(Constants.CXF_IN_FAULT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorA, BarInterceptor");
+         properties.put(Constants.CXF_OUT_FAULT_INTERCEPTORS_PROP, "org.jboss.wsf.stack.cxf.client.configuration.InterceptorC");
          clientConfig = new ClientConfig("Foo2", null, null, properties, null);
          
          cfg.setConfigProperties(port, clientConfig);
@@ -334,15 +479,44 @@ public class CXFClientConfigurerTest
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorZ"));
          interceptors = toNameList(client.getOutInterceptors());
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
-         
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         interceptors = toNameList(client.getInFaultInterceptors());
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorY"));
+         assertFalse(interceptors.contains("BarInterceptor"));
+         interceptors = toNameList(client.getOutFaultInterceptors());
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+
          properties = new HashMap<String, String>();
          properties.put(Constants.CXF_IN_INTERCEPTORS_PROP, "");
+         properties.put(Constants.CXF_IN_FAULT_INTERCEPTORS_PROP, "");
          clientConfig = new ClientConfig("Foo2", null, null, properties, null);
          
          cfg.setConfigProperties(port, clientConfig);
@@ -359,13 +533,40 @@ public class CXFClientConfigurerTest
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
          assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorZ"));
          interceptors = toNameList(client.getOutInterceptors());
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
          assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
-
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         interceptors = toNameList(client.getInFaultInterceptors());
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
+         assertTrue(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorY"));
+         assertFalse(interceptors.contains("BarInterceptor"));
+         interceptors = toNameList(client.getOutFaultInterceptors());
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorA"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorB"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorC"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorD"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorE"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorF"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorG"));
+         assertFalse(interceptors.contains("org.jboss.wsf.stack.cxf.client.configuration.InterceptorH"));
       } finally {
          if (bus != null) {
             bus.shutdown(true);

--- a/modules/client/src/test/java/org/jboss/wsf/stack/cxf/client/configuration/InterceptorE.java
+++ b/modules/client/src/test/java/org/jboss/wsf/stack/cxf/client/configuration/InterceptorE.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.wsf.stack.cxf.client.configuration;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.interceptor.Interceptor;
+import org.apache.cxf.message.Message;
+
+public class InterceptorE implements Interceptor<Message> {
+
+   @Override
+   public void handleMessage(Message message) throws Fault
+   {
+      // TODO Auto-generated method stub
+      
+   }
+
+   @Override
+   public void handleFault(Message message)
+   {
+      // TODO Auto-generated method stub
+      
+   }
+
+}

--- a/modules/client/src/test/java/org/jboss/wsf/stack/cxf/client/configuration/InterceptorF.java
+++ b/modules/client/src/test/java/org/jboss/wsf/stack/cxf/client/configuration/InterceptorF.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.wsf.stack.cxf.client.configuration;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.interceptor.Interceptor;
+import org.apache.cxf.message.Message;
+
+public class InterceptorF implements Interceptor<Message> {
+
+   @Override
+   public void handleMessage(Message message) throws Fault
+   {
+      // TODO Auto-generated method stub
+      
+   }
+
+   @Override
+   public void handleFault(Message message)
+   {
+      // TODO Auto-generated method stub
+      
+   }
+
+}

--- a/modules/client/src/test/java/org/jboss/wsf/stack/cxf/client/configuration/InterceptorG.java
+++ b/modules/client/src/test/java/org/jboss/wsf/stack/cxf/client/configuration/InterceptorG.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.wsf.stack.cxf.client.configuration;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.interceptor.Interceptor;
+import org.apache.cxf.message.Message;
+
+public class InterceptorG implements Interceptor<Message> {
+
+   @Override
+   public void handleMessage(Message message) throws Fault
+   {
+      // TODO Auto-generated method stub
+      
+   }
+
+   @Override
+   public void handleFault(Message message)
+   {
+      // TODO Auto-generated method stub
+      
+   }
+
+}

--- a/modules/client/src/test/java/org/jboss/wsf/stack/cxf/client/configuration/InterceptorH.java
+++ b/modules/client/src/test/java/org/jboss/wsf/stack/cxf/client/configuration/InterceptorH.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.wsf.stack.cxf.client.configuration;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.interceptor.Interceptor;
+import org.apache.cxf.message.Message;
+
+public class InterceptorH implements Interceptor<Message> {
+
+   @Override
+   public void handleMessage(Message message) throws Fault
+   {
+      // TODO Auto-generated method stub
+      
+   }
+
+   @Override
+   public void handleFault(Message message)
+   {
+      // TODO Auto-generated method stub
+      
+   }
+
+}

--- a/modules/client/src/test/java/org/jboss/wsf/stack/cxf/client/configuration/InterceptorY.java
+++ b/modules/client/src/test/java/org/jboss/wsf/stack/cxf/client/configuration/InterceptorY.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.wsf.stack.cxf.client.configuration;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.interceptor.Interceptor;
+import org.apache.cxf.message.Message;
+
+public class InterceptorY implements Interceptor<Message> {
+
+   @Override
+   public void handleMessage(Message message) throws Fault
+   {
+      // TODO Auto-generated method stub
+      
+   }
+
+   @Override
+   public void handleFault(Message message)
+   {
+      // TODO Auto-generated method stub
+      
+   }
+
+}


### PR DESCRIPTION
Proposed solution for the JBWS-4077 feature enhancement, including adapted unit tests.

The purpose of this enhancement is to introduce two new properties into the JBossWS configuration, "cxf.interceptors.infault" and "cxf.interceptors.outfault", that allow services to register InFault and OutFault interceptors respectively, in the same vein as the existing "cxf.interceptors.in" and "cxf.interceptors.out" properties for In and Out interceptors.