### PR TITLE
[JBWS-4083] set required new security-manager flag -secmgr

### DIFF
--- a/modules/testsuite/shared-tests/src/test/java/org/jboss/test/ws/jaxws/jbws2528/JBWS2528TestCase.java
+++ b/modules/testsuite/shared-tests/src/test/java/org/jboss/test/ws/jaxws/jbws2528/JBWS2528TestCase.java
@@ -40,6 +40,7 @@ import org.jboss.wsf.test.JBossWSTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.jboss.wsf.test.JBossWSTestHelper;
 
 /**
  * [JBWS-2528] Missing parameterOrder in portType/operation
@@ -78,8 +79,21 @@ public class JBWS2528TestCase extends JBossWSTest
       File destDir = new File(TEST_DIR, "wsprovide" + FS + "java");
       String absOutput = destDir.getAbsolutePath();
       String command = JBOSS_HOME + FS + "bin" + FS + "wsprovide" + EXT + " -k -w -o " + absOutput + " --classpath " + CLASSES_DIR + " " + ENDPOINT_CLASS;
+
+      // wildfly9 security manager flag changed from -Djava.security.manager to -secmgr.
+      // Can't pass -secmgr arg through arquillian because it breaks arquillian's
+      // config of our tests.
+      // the -secmgr flag MUST be provided as an input arg to jboss-modules so it must
+      // come after the jboss-modules.jar ref.
+      String additionalJVMArgs = System.getProperty("additionalJvmArgs", "");
+      String securityManagerDesignator = additionalJVMArgs.replace("-Djava.security.manager", "-secmgr");
+
+
+      File policyFile = new File(JBossWSTestHelper.getTestResourcesDir() + "/jaxws/jbws2528/jbws2528-security.policy");
+      String securityPolicyFile = " -Djava.security.policy=" + policyFile.getCanonicalPath();
+
       Map<String, String> env = new HashMap<>();
-      env.put("JAVA_OPTS", System.getProperty("additionalJvmArgs"));
+      env.put("JAVA_OPTS", securityManagerDesignator + securityPolicyFile);
       executeCommand(command, null, "wsprovide", env);
 
       URL wsdlURL = new File(destDir, "JBWS2528EndpointService.wsdl").toURI().toURL();

--- a/modules/testsuite/shared-tests/src/test/java/org/jboss/test/ws/jaxws/jbws2529/JBWS2529TestCase.java
+++ b/modules/testsuite/shared-tests/src/test/java/org/jboss/test/ws/jaxws/jbws2529/JBWS2529TestCase.java
@@ -37,6 +37,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.w3c.dom.Element;
+import org.jboss.wsf.test.JBossWSTestHelper;
+
 /** 
  * [JBWS-2529] Missing type in generated WSDL part definition
  * 
@@ -75,8 +77,20 @@ public class JBWS2529TestCase extends JBossWSTest
       File destDir = new File(TEST_DIR, "wsprovide" + FS + "java");
       String absOutput = destDir.getAbsolutePath();
       String command = JBOSS_HOME + FS + "bin" + FS + "wsprovide" + EXT + " -k -w -o " + absOutput + " --classpath " + CLASSES_DIR + " " + ENDPOINT_CLASS;
+
+      // wildfly9 security manager flag changed from -Djava.security.manager to -secmgr.
+      // Can't pass -secmgr arg through arquillian because it breaks arquillian's
+      // config of our tests.
+      // the -secmgr flag MUST be provided as an input arg to jboss-modules so it must
+      // come after the jboss-modules.jar ref.
+      String additionalJVMArgs = System.getProperty("additionalJvmArgs", "");
+      String securityManagerDesignator = additionalJVMArgs.replace("-Djava.security.manager", "-secmgr");
+
+      File policyFile = new File(JBossWSTestHelper.getTestResourcesDir() + "/jaxws/jbws2529/jbws2529-security.policy");
+      String securityPolicyFile = " -Djava.security.policy=" + policyFile.getCanonicalPath();
+
       Map<String, String> env = new HashMap<>();
-      env.put("JAVA_OPTS", System.getProperty("additionalJvmArgs"));
+      env.put("JAVA_OPTS", securityManagerDesignator + securityPolicyFile);
       executeCommand(command, null, "wsprovide", env);
       
       File wsdl = new File(destDir, isIntegrationCXF() ? "JBWS2529EndpointService_schema1.xsd" : "JBWS2529EndpointService.wsdl");

--- a/modules/testsuite/shared-tests/src/test/java/org/jboss/test/ws/jaxws/jbws2591/JBWS2591TestCase.java
+++ b/modules/testsuite/shared-tests/src/test/java/org/jboss/test/ws/jaxws/jbws2591/JBWS2591TestCase.java
@@ -33,6 +33,7 @@ import org.jboss.wsf.test.JBossWSTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.jboss.wsf.test.JBossWSTestHelper;
 
 /**
  * [JBWS-2591] WSConsume does not generate @XmlList with doc/lit wsdl
@@ -70,8 +71,22 @@ public class JBWS2591TestCase extends JBossWSTest
       String absWsdlLoc = getResourceFile(WSDL_LOCATION).getAbsolutePath();
       String absOutput = new File(TEST_DIR, "wsconsume" + FS + "java").getAbsolutePath();
       String command = JBOSS_HOME + FS + "bin" + FS + "wsconsume" + EXT + " -v -k -o " + absOutput + " " + absWsdlLoc;
+
+      // wildfly9 security manager flag changed from -Djava.security.manager to -secmgr.
+      // Can't pass -secmgr arg through arquillian because it breaks arquillian's
+      // config of our tests.
+      // the -secmgr flag MUST be provided as an input arg to jboss-modules so it must
+      // come after the jboss-modules.jar ref.
+      String additionalJVMArgs = System.getProperty("additionalJvmArgs", "");
+      String securityManagerDesignator = additionalJVMArgs.replace("-Djava.security.manager", "-secmgr");
+
+      File policyFile = new File(JBossWSTestHelper.getTestResourcesDir()
+          + "/jaxws/jbws2591/jbws2591-security.policy");
+      String securityPolicyFile = " -Djava.security.policy=" + policyFile.getCanonicalPath();
+
       Map<String, String> env = new HashMap<>();
-      env.put("JAVA_OPTS", System.getProperty("additionalJvmArgs"));
+      env.put("JAVA_OPTS", securityManagerDesignator + securityPolicyFile);
+
       executeCommand(command, null, "wsconsume", env);
       File javaSource = new File(TEST_DIR, "wsconsume" + FS + "java" + FS + "org" + FS + "marshalltestservice" + FS + "newschemadefs" + FS + "NewSchemaTest.java");
       assertTrue("Service endpoint interface not generated", javaSource.exists());

--- a/modules/testsuite/shared-tests/src/test/java/org/jboss/test/ws/jaxws/jbws2593/JBWS2593TestCase.java
+++ b/modules/testsuite/shared-tests/src/test/java/org/jboss/test/ws/jaxws/jbws2593/JBWS2593TestCase.java
@@ -33,6 +33,7 @@ import org.jboss.wsf.test.JBossWSTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.jboss.wsf.test.JBossWSTestHelper;
 
 /**
  * [JBWS-2593] WSConsume does not generate @XmlJavaTypeAdapter in SEI
@@ -83,8 +84,22 @@ public class JBWS2593TestCase extends JBossWSTest
       String absWsdlLoc = getResourceFile(rpc ? WSDL_LOCATION_RPC : WSDL_LOCATION_DOC).getAbsolutePath();
       String absOutput = new File(TEST_DIR, "wsconsume" + FS + "java").getAbsolutePath();
       String command = JBOSS_HOME + FS + "bin" + FS + "wsconsume" + EXT + " -v -k -o " + absOutput + " " + absWsdlLoc;
+
+      // wildfly9 security manager flag changed from -Djava.security.manager to -secmgr.
+      // Can't pass -secmgr arg through arquillian because it breaks arquillian's
+      // config of our tests.
+      // the -secmgr flag MUST be provided as an input arg to jboss-modules so it must
+      // come after the jboss-modules.jar ref.
+      String additionalJVMArgs = System.getProperty("additionalJvmArgs", "");
+      String securityManagerDesignator = additionalJVMArgs.replace("-Djava.security.manager", "-secmgr");
+
+      File policyFile = new File(JBossWSTestHelper.getTestResourcesDir()
+          + "/jaxws/jbws2593/jbws2593-security.policy");
+      String securityPolicyFile = " -Djava.security.policy=" + policyFile.getCanonicalPath();
+
       Map<String, String> env = new HashMap<>();
-      env.put("JAVA_OPTS", System.getProperty("additionalJvmArgs"));
+      env.put("JAVA_OPTS", securityManagerDesignator + securityPolicyFile);
+
       executeCommand(command, null, "wsconsume", env);
       File javaSource = new File(TEST_DIR, "wsconsume" + FS + "java" + FS + "org" + FS + "jbws2593_" + (rpc ? "rpc" : "doc") + FS + "ParameterModeTest.java");
       assertTrue("Service endpoint interface not generated", javaSource.exists());

--- a/modules/testsuite/shared-tests/src/test/java/org/jboss/test/ws/jaxws/smoke/tools/WSConsumeScriptTestCase.java
+++ b/modules/testsuite/shared-tests/src/test/java/org/jboss/test/ws/jaxws/smoke/tools/WSConsumeScriptTestCase.java
@@ -42,7 +42,7 @@ import org.junit.runner.RunWith;
  * @author Heiko.Braun@jboss.com
  */
 @RunWith(Arquillian.class)
-public class WSConsumeScriptTestCase extends ScriptTestCase
+public class WSConsumeScriptTestCase extends org.jboss.test.ws.jaxws.smoke.tools.ScriptTestCase
 {
    private String WSDL_LOCATION = "jaxws" + FS + "smoke" + FS + "tools" + FS + "wsdl" + FS + "TestServiceCatalog.wsdl";
 
@@ -54,8 +54,17 @@ public class WSConsumeScriptTestCase extends ScriptTestCase
       String absWsdlLoc = getResourceFile(WSDL_LOCATION).getAbsolutePath();
       String absOutput = new File(TEST_DIR, "wsconsume" + FS + "java").getAbsolutePath();
       String command = JBOSS_HOME + FS + "bin" + FS + "wsconsume" + EXT + " -v -k -o " + absOutput + " " + absWsdlLoc;
+
+      // wildfly9 security manager flag changed from -Djava.security.manager to -secmgr.
+      // Can't pass -secmgr arg through arquillian because it breaks arquillian's
+      // config of our tests.
+      // the -secmgr flag MUST be provided as an input arg to jboss-modules so it must
+      // come after the jboss-modules.jar ref.
+      String additionalJVMArgs = System.getProperty("additionalJvmArgs", "");
+      String securityManagerDesignator = additionalJVMArgs.replace("-Djava.security.manager", "-secmgr");
+
       Map<String, String> env = new HashMap<>();
-      env.put("JAVA_OPTS", System.getProperty("additionalJvmArgs"));
+      env.put("JAVA_OPTS", securityManagerDesignator);
       executeCommand(command, null, "wsconsume", env);
       File javaSource = new File(TEST_DIR, "wsconsume" + FS + "java" + FS + "org" + FS + "openuri" + FS + "_2004" + FS + "_04" + FS + "helloworld" + FS + "EndpointInterface.java");
       assertTrue("Service endpoint interface not generated", javaSource.exists());

--- a/modules/testsuite/shared-tests/src/test/java/org/jboss/test/ws/jaxws/smoke/tools/WSProvideScriptTestCase.java
+++ b/modules/testsuite/shared-tests/src/test/java/org/jboss/test/ws/jaxws/smoke/tools/WSProvideScriptTestCase.java
@@ -29,6 +29,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.jboss.wsf.test.JBossWSTestHelper;
 
 /**
  * [JBWS-1793] Provide a test case for the tools scripts that reside under JBOSS_HOME/bin
@@ -42,7 +43,7 @@ import org.junit.runner.RunWith;
  * @author Heiko.Braun@jboss.com
  */
 @RunWith(Arquillian.class)
-public class WSProvideScriptTestCase extends ScriptTestCase
+public class WSProvideScriptTestCase extends org.jboss.test.ws.jaxws.smoke.tools.ScriptTestCase
 {
    @Test
    @RunAsClient
@@ -50,8 +51,22 @@ public class WSProvideScriptTestCase extends ScriptTestCase
    {
       String absOutput = new File(TEST_DIR, "wsprovide" + FS + "java").getAbsolutePath();
       String command = JBOSS_HOME + FS + "bin" + FS + "wsprovide" + EXT + " -k -w -o " + absOutput + " --classpath " + CLASSES_DIR + " " + ENDPOINT_CLASS;
+
+      // wildfly9 security manager flag changed from -Djava.security.manager to -secmgr.
+      // Can't pass -secmgr arg through arquillian because it breaks arquillian's
+      // config of our tests.
+      // the -secmgr flag MUST be provided as an input arg to jboss-modules so it must
+      // come after the jboss-modules.jar ref.
+      String additionalJVMArgs = System.getProperty("additionalJvmArgs", "");
+      String securityManagerDesignator = additionalJVMArgs.replace("-Djava.security.manager", "-secmgr");
+
+      File policyFile = new File(JBossWSTestHelper.getTestResourcesDir()
+          + "/jaxws/smoke/tools/WSProvideScriptTestCase-security.policy");
+      String securityPolicyFile = " -Djava.security.policy=" + policyFile.getCanonicalPath();
+
       Map<String, String> env = new HashMap<>();
-      env.put("JAVA_OPTS", System.getProperty("additionalJvmArgs"));
+      env.put("JAVA_OPTS", securityManagerDesignator + securityPolicyFile);
+
       executeCommand(command, null, "wsprovide", env);
       File javaSource = new File(TEST_DIR, "wsprovide" + FS + "java" + FS + "org" + FS + "jboss" + FS + "test" + FS + "ws" + FS + "jaxws" + FS + "smoke" + FS + "tools" + FS + "jaxws" + FS + "AddResponse.java");
       assertTrue("Response wrapper not generated", javaSource.exists());

--- a/modules/testsuite/shared-tests/src/test/resources/jaxws/jbws2528/jbws2528-security.policy
+++ b/modules/testsuite/shared-tests/src/test/resources/jaxws/jbws2528/jbws2528-security.policy
@@ -1,0 +1,3 @@
+grant {
+    permission java.security.AllPermission;
+};

--- a/modules/testsuite/shared-tests/src/test/resources/jaxws/jbws2529/jbws2529-security.policy
+++ b/modules/testsuite/shared-tests/src/test/resources/jaxws/jbws2529/jbws2529-security.policy
@@ -1,0 +1,3 @@
+grant {
+    permission java.security.AllPermission;
+};

--- a/modules/testsuite/shared-tests/src/test/resources/jaxws/jbws2591/jbws2591-security.policy
+++ b/modules/testsuite/shared-tests/src/test/resources/jaxws/jbws2591/jbws2591-security.policy
@@ -1,0 +1,3 @@
+grant {
+    permission java.security.AllPermission;
+};

--- a/modules/testsuite/shared-tests/src/test/resources/jaxws/jbws2593/jbws2593-security.policy
+++ b/modules/testsuite/shared-tests/src/test/resources/jaxws/jbws2593/jbws2593-security.policy
@@ -1,0 +1,3 @@
+grant {
+    permission java.security.AllPermission;
+};

--- a/modules/testsuite/shared-tests/src/test/resources/jaxws/smoke/tools/WSProvideScriptTestCase-security.policy
+++ b/modules/testsuite/shared-tests/src/test/resources/jaxws/smoke/tools/WSProvideScriptTestCase-security.policy
@@ -1,0 +1,3 @@
+grant {
+    permission java.security.AllPermission;
+};


### PR DESCRIPTION
Wildfly moving from security manager flag -Djava.security.manager to -secmgr
requires a change to jboss-modules [1] and a change to wildfly scripts 
wsprovide.*[2] and wsconsume.*[3].  The integration of these jiras are
required before the code changes for this PR will work.

[1] https://issues.jboss.org/browse/MODULES-307
[2] https://issues.jboss.org/browse/WFLY-9538
[3] https://issues.jboss.org/browse/WFLY-9539