### PR TITLE
[JBWS-4098] Reenable testsuite server logging via commandline property

### DIFF
--- a/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-default-config-tests-elytron.groovy
+++ b/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-default-config-tests-elytron.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 /**

--- a/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-default-config-tests.groovy
+++ b/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-default-config-tests.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-default-elytron.groovy
+++ b/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-default-elytron.groovy
@@ -7,7 +7,7 @@ def root = new XmlParser().parse(inputFile)
 
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-default.groovy
+++ b/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-default.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-jms-wildfly1000.groovy
+++ b/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-jms-wildfly1000.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-jms-wildfly1010.groovy
+++ b/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-jms-wildfly1010.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-jms-wildfly1100.groovy
+++ b/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-jms-wildfly1100.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-jms-wildfly1200.groovy
+++ b/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-jms-wildfly1200.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-ssl-mutual-auth-elytron.groovy
+++ b/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-ssl-mutual-auth-elytron.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-ssl-mutual-auth.groovy
+++ b/modules/testsuite/cxf-tests/src/test/scripts/jbws-testsuite-ssl-mutual-auth.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/perf-tests/src/test/scripts/perf.groovy
+++ b/modules/testsuite/perf-tests/src/test/scripts/perf.groovy
@@ -9,7 +9,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-address-rewrite-elytron.groovy
+++ b/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-address-rewrite-elytron.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-address-rewrite.groovy
+++ b/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-address-rewrite.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-default-config-tests-elytron.groovy
+++ b/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-default-config-tests-elytron.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-default-config-tests.groovy
+++ b/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-default-config-tests.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-default-elytron.groovy
+++ b/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-default-elytron.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 

--- a/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-default.groovy
+++ b/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-default.groovy
@@ -6,7 +6,7 @@ def root = new XmlParser().parse(inputFile)
  */
 def logHandlers = root.profile.subsystem.'root-logger'.handlers[0]
 def consoleHandler = logHandlers.find{it.@name == 'CONSOLE'}
-if (!project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
+if (!session.userProperties['enableServerLoggingToConsole'] && !project.properties['enableServerLoggingToConsole']) logHandlers.remove(consoleHandler)
 def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4098

gmavenplus-plugin changed how are commandline properties passed,  'project.properties' are now only for properties defined in pom.xml. For commandline properties 'session.userProperties' should be used. I extended the condition so that commandline-defined property works again.