### PR TITLE
[JBWS-4104] Fix elytron configuration by version-agnostic subsystem pick

### DIFF
--- a/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-address-rewrite-elytron.groovy
+++ b/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-address-rewrite-elytron.groovy
@@ -12,6 +12,17 @@ file.attributes()['path'] = serverLog
 
 
 /**
+ * Helper method to get subsystem element by xmlns prefix
+ */
+private getSubsystem(root, xmlnsPrefix) {
+  for (item in root.profile.subsystem) {
+    if (item.name().getNamespaceURI().startsWith(xmlnsPrefix)) {
+      return item;
+    }
+  }
+}
+
+/**
  * Add a security-domain block like this:
  *
  *        <subsystem xmlns="urn:wildfly:elytron:1.0">
@@ -23,19 +34,12 @@ file.attributes()['path'] = serverLog
  * 
  *
  */
-def subsystems = root.profile.subsystem
-def securitySubsystem = null
+def securitySubsystem =  getSubsystem(root, "urn:wildfly:elytron:")
 def securityDomains = null
-for (item in subsystems) {
-    if (item.name().getNamespaceURI().contains("urn:wildfly:elytron:")) {
-       securitySubsystem = item
-       for (element in item) {
-           if (element.name().getLocalPart() == 'security-domains') {
-              securityDomains = element
-           }
-       }
-       break
-    }
+for (element in securitySubsystem) {
+  if (element.name().getLocalPart() == 'security-domains') {
+    securityDomains = element
+  }
 }
 def securityDomain = securityDomains.appendNode('security-domain', ['name':'JBossWS','default-realm':'JBossWS','permission-mapper':'default-permission-mapper'])
 def realm = securityDomain.appendNode('realm',['name':'JBossWS','role-decoder':'groups-to-roles'])

--- a/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-default-config-tests-elytron.groovy
+++ b/modules/testsuite/shared-tests/src/test/scripts/jbws-testsuite-shared-default-config-tests-elytron.groovy
@@ -11,6 +11,17 @@ def file = root.profile.subsystem.'periodic-rotating-file-handler'.file[0]
 file.attributes()['path'] = serverLog
 
 /**
+ * Helper method to get subsystem element by xmlns prefix
+ */
+private getSubsystem(root, xmlnsPrefix) {
+  for (item in root.profile.subsystem) {
+    if (item.name().getNamespaceURI().startsWith(xmlnsPrefix)) {
+      return item;
+    }
+  }
+}
+
+/**
  * Add a security-domain block like this:
  *
  *        <subsystem xmlns="urn:wildfly:elytron:1.0">
@@ -22,19 +33,12 @@ file.attributes()['path'] = serverLog
  * 
  *
  */
-def subsystems = root.profile.subsystem
-def securitySubsystem = null;
+def securitySubsystem =  getSubsystem(root, "urn:wildfly:elytron:")
 def securityDomains = null
-for (item in subsystems) {
-    if (item.name().getNamespaceURI().contains("urn:wildfly:elytron:")) {
-       securitySubsystem = item;
-       for (element in item) {
-           if (element.name().getLocalPart() == 'security-domains') {
-              securityDomains = element
-           }
-       }
-       break
-    }
+for (element in securitySubsystem) {
+  if (element.name().getLocalPart() == 'security-domains') {
+    securityDomains = element
+  }
 }
 def securityDomain = securityDomains.appendNode('security-domain', ['name':'JBossWS','default-realm':'JBossWS','permission-mapper':'default-permission-mapper'])
 def realm = securityDomain.appendNode('realm',['name':'JBossWS','role-decoder':'groups-to-roles'])
@@ -72,9 +76,7 @@ def mechanismRealm=mechanism.appendNode('mechanism-realm',['realm-name':'JBossWS
 
 
 //add to undertow
-def undertowns = new groovy.xml.Namespace('urn:jboss:domain:undertow:4.0')
-def wflyns = new groovy.xml.Namespace('urn:jboss:domain:5.0')
-def undertowSubsystem = root[wflyns.profile][undertowns.subsystem][0]
+def undertowSubsystem = getSubsystem(root, "urn:jboss:domain:undertow:")
 
 //TODO: is there better create node as sibling in groovy
 def undertowChildren = undertowSubsystem.children()


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4104

Don't bind configuration to eg. "urn:jboss:domain:undertow:4.0" because this can change often, use just "urn:jboss:domain:undertow:" prefix to pick the correct subsystem. Also fixed syntax typo created during migration to new plugin.