### PR TITLE
[JBWS-4142] Dependencies versions update - non-cxf components

### DIFF
--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/noIntegration/AS7537TestCase.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/noIntegration/AS7537TestCase.java
@@ -88,7 +88,7 @@ public class AS7537TestCase extends JBossWSTest
          fail("Deployment failure expected");
       } catch (Exception e) {
          undeploy = false;
-         assertTrue(e.getCause().getMessage().contains("JBAS015599") || e.getCause().getMessage().contains("WFLYWS0059"));
+         assertTrue(e.getMessage().contains("JBAS015599") || e.getMessage().contains("WFLYWS0059"));
       } finally {
          if (undeploy) {
             try {

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
   
   <!-- Properties -->
   <properties>
-    <jboss.modules.version>1.7.0.Final</jboss.modules.version>
+    <jboss.modules.version>1.8.6.Final</jboss.modules.version>
     <jbossws.api.version>1.1.2-SNAPSHOT</jbossws.api.version>
     <jbossws.spi.version>3.2.3-SNAPSHOT</jbossws.spi.version>
     <jbossws.common.version>3.2.2-SNAPSHOT</jbossws.common.version>
@@ -78,46 +78,47 @@
     <cxf.version>3.2.5-jbossorg-1</cxf.version>
     <cxf.asm.version>6.2.1</cxf.asm.version>
     <cxf.xjcplugins.version>3.1.0</cxf.xjcplugins.version>
-    <jboss-logging.version>3.3.1.Final</jboss-logging.version>
+    <jboss-logging.version>3.3.2.Final</jboss-logging.version>
     <jboss-logging-annotations.version>2.1.0.Final</jboss-logging-annotations.version>
     <jboss-logging-processor.version>2.1.0.Final</jboss-logging-processor.version>
     <jboss.xb.version>2.0.3.GA</jboss.xb.version>
-    <picketbox.version>4.0.19.Final</picketbox.version>
-    <picketlink.version>2.5.2.Final</picketlink.version>
+    <picketbox.version>5.0.3.Final</picketbox.version>
+    <picketlink.version>2.5.5.SP12</picketlink.version>
     <jaxws-undertow-httpspi.version>1.0.1.Final</jaxws-undertow-httpspi.version>
-    <io.undertow.version>1.0.10.Final</io.undertow.version>
-    <jaxb.api.version>1.0.0.Final</jaxb.api.version>
+    <io.undertow.version>2.0.13.Final</io.undertow.version>
+    <jaxb.api.version>1.0.1.Final</jaxb.api.version>
     <jaxb.impl.version>2.3.0</jaxb.impl.version>
-    <jaxws.api.version>1.0.0.Beta1</jaxws.api.version>
+    <jaxws.api.version>1.0.0.Final</jaxws.api.version>
     <jsr181.api.version>1.0-MR1</jsr181.api.version>
-    <commons-beanutils.version>1.9.2</commons-beanutils.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
-    <commons-lang3.version>3.6</commons-lang3.version>
-    <commons.logging.version>1.1.1</commons.logging.version>
-    <log4j.version>1.2.16</log4j.version>
+    <commons-beanutils.version>1.9.3</commons-beanutils.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
+    <commons-lang3.version>3.8.1</commons-lang3.version>
+    <commons.logging.version>1.2</commons.logging.version>
+    <log4j.version>1.2.17</log4j.version>
     <org.slf4j.version>1.7.25</org.slf4j.version>
-    <activation.version>1.1</activation.version>
-    <fastinfoset.version>1.2.12</fastinfoset.version>
+    <activation.version>1.1.1</activation.version>
+    <fastinfoset.version>1.2.15</fastinfoset.version>
     <neethi.version>3.1.1</neethi.version>
     <opensaml.version>3.3.0</opensaml.version>
-    <annotation.api.version>1.0.0.Final</annotation.api.version>
-    <saaj.api.version>1.0.4.Final</saaj.api.version>
-    <servlet.api.version>1.0.0.Final</servlet.api.version>
+    <annotation.api.version>1.0.2.Final</annotation.api.version>
+    <saaj.api.version>1.0.6.Final</saaj.api.version>
+    <servlet.api.version>1.0.2.Final</servlet.api.version>
     <stax.api.version>1.0-2</stax.api.version>
-    <jms.api.version>1.0.0.Final</jms.api.version>
+    <jms.api.version>1.0.2.Final</jms.api.version>
     <velocity.version>2.0</velocity.version>
-    <xerces.version>2.9.1</xerces.version>
+    <xerces.version>2.12.0.SP02</xerces.version>
     <xmlsec.version>2.1.2</xmlsec.version>
     <wss4j.version>2.2.2</wss4j.version>
     <wstx.version>5.0.3</wstx.version>
-    <shrinkwrap.version>1.1.3</shrinkwrap.version>
-    <derby.version>10.2.2.0</derby.version>
+    <shrinkwrap.version>1.2.6</shrinkwrap.version>
+    <derby.version>10.14.2.0</derby.version>
     <arquillian.version>1.1.11.Final</arquillian.version>
-    <arquillian-wildfly-container.version>2.0.0.Final</arquillian-wildfly-container.version>
+    <arquillian-wildfly-container.version>2.1.1.Final</arquillian-wildfly-container.version>
     <version.commons.validator>1.6</version.commons.validator>
-    <jaspi.api.version>1.0.0.Alpha1</jaspi.api.version>
-    <jacc.api.version>1.0.0.Final</jacc.api.version>
+    <jaspi.api.version>1.0.2.Final</jaspi.api.version>
+    <jacc.api.version>1.0.2.Final</jacc.api.version>
     <javax.inject.version>1</javax.inject.version>
+    <org.easymock.version>3.2</org.easymock.version>
     <modular.jdk.args />
     <modular.jdk.props />
   </properties>
@@ -1251,7 +1252,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymockclassextension</artifactId>
-        <version>2.4</version>
+        <version>${org.easymock.version}</version>
       </dependency>
       
       <!-- Other test dependencies -->
@@ -1336,7 +1337,7 @@
           <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-cli</artifactId>
-            <version>8.1.0.Final</version>
+            <version>8.2.1.Final</version>
             <exclusions>
               <exclusion>
                 <groupId>sun.jdk</groupId>
@@ -1355,7 +1356,7 @@
           <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jbossorg-docbook-xslt</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
             <!-- TODO workaround for https://issues.jboss.org/browse/PRESSGANG-60,
                  could be removed if new org.jboss.pressgang extensions are used instead -->
             <exclusions>
@@ -1372,7 +1373,7 @@
           <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jbossorg-jdocbook-style</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.1</version>
             <type>jdocbook-style</type>
             <!-- TODO workaround for https://issues.jboss.org/browse/PRESSGANG-60,
                  could be removed if new org.jboss.pressgang extensions are used instead -->


### PR DESCRIPTION
[JBWS-4142] Dependencies versions update - non-cxf components
https://issues.jboss.org/browse/JBWS-4142

Align with latest available (and applicable) versions ++ WF codebase based versions.