### PR TITLE
[JBWS-4139] Update JAXB to 2.3.1

### DIFF
--- a/modules/addons/transports/udp/pom.xml
+++ b/modules/addons/transports/udp/pom.xml
@@ -28,20 +28,16 @@
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-xjc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-core</artifactId>
       <exclusions>
         <exclusion>
           <groupId>javax.xml.bind</groupId>
           <artifactId>jaxb-api</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-xjc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>

--- a/modules/client/pom.xml
+++ b/modules/client/pom.xml
@@ -218,20 +218,16 @@
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
       <artifactId>jaxb-runtime</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-xjc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-core</artifactId>
       <exclusions>
         <exclusion>
           <groupId>javax.xml.bind</groupId>
           <artifactId>jaxb-api</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-xjc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>

--- a/modules/server/pom.xml
+++ b/modules/server/pom.xml
@@ -215,16 +215,6 @@
     </dependency>
     <dependency>
       <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
       <artifactId>codemodel</artifactId>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <jaxws-undertow-httpspi.version>1.0.1.Final</jaxws-undertow-httpspi.version>
     <io.undertow.version>2.0.13.Final</io.undertow.version>
     <jaxb.api.version>1.0.1.Final</jaxb.api.version>
-    <jaxb.impl.version>2.3.0</jaxb.impl.version>
+    <jaxb.impl.version>2.3.1</jaxb.impl.version>
     <jaxws.api.version>1.0.0.Final</jaxws.api.version>
     <jsr181.api.version>1.0-MR1</jsr181.api.version>
     <commons-beanutils.version>1.9.3</commons-beanutils.version>
@@ -1192,15 +1192,16 @@
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
         <version>${jaxb.impl.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-xjc</artifactId>
-        <version>${jaxb.impl.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.glassfish.jaxb</groupId>
-        <artifactId>jaxb-core</artifactId>
         <version>${jaxb.impl.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4139
Update JAXB to 2.3.1 to bring in changes and fixes for JDK11
Changeset https://github.com/javaee/jaxb-v2/compare/2.3.0...2.3.1

Notable changes: 
- jaxb-core artifact is no longer present, content merged into jaxb-runtime https://github.com/javaee/jaxb-v2/commit/32fda2fbee71c2df04c52fc8eb3687699869ae0b
- relaxngDatatype:relaxngDatatype dependency replaced with com.sun.xml.bind.external:relaxng-datatype https://github.com/javaee/jaxb-v2/commit/593f1fbc2d4712a751ebfc45f196900ce070da9f - this is not addressed in this PR yet, consultation needed