### PR TITLE
[JBWS-4145] Add elytron dependency to all wsconsume & wsprovide modules

### DIFF
--- a/modules/resources/src/main/resources/modules/wildfly1300/org/jboss/ws/tools/wsconsume/main/module.xml
+++ b/modules/resources/src/main/resources/modules/wildfly1300/org/jboss/ws/tools/wsconsume/main/module.xml
@@ -34,6 +34,7 @@
     <dependencies>
         <module name="org.jboss.logmanager" services="import"/>
         <module name="org.jboss.ws.tools.common"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
 
 </module>

--- a/modules/resources/src/main/resources/modules/wildfly1300/org/jboss/ws/tools/wsprovide/main/module.xml
+++ b/modules/resources/src/main/resources/modules/wildfly1300/org/jboss/ws/tools/wsprovide/main/module.xml
@@ -34,6 +34,7 @@
     <dependencies>
         <module name="org.jboss.logmanager" services="import"/>
         <module name="org.jboss.ws.tools.common"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
 
 </module>

--- a/modules/resources/src/main/resources/modules/wildfly1400/org/jboss/ws/tools/wsconsume/main/module.xml
+++ b/modules/resources/src/main/resources/modules/wildfly1400/org/jboss/ws/tools/wsconsume/main/module.xml
@@ -34,6 +34,7 @@
     <dependencies>
         <module name="org.jboss.logmanager" services="import"/>
         <module name="org.jboss.ws.tools.common"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
 
 </module>

--- a/modules/resources/src/main/resources/modules/wildfly1400/org/jboss/ws/tools/wsprovide/main/module.xml
+++ b/modules/resources/src/main/resources/modules/wildfly1400/org/jboss/ws/tools/wsprovide/main/module.xml
@@ -34,6 +34,7 @@
     <dependencies>
         <module name="org.jboss.logmanager" services="import"/>
         <module name="org.jboss.ws.tools.common"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
 
 </module>

--- a/modules/resources/src/main/resources/modules/wildfly1500/org/jboss/ws/tools/wsconsume/main/module.xml
+++ b/modules/resources/src/main/resources/modules/wildfly1500/org/jboss/ws/tools/wsconsume/main/module.xml
@@ -34,6 +34,7 @@
     <dependencies>
         <module name="org.jboss.logmanager" services="import"/>
         <module name="org.jboss.ws.tools.common"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
 
 </module>

--- a/modules/resources/src/main/resources/modules/wildfly1500/org/jboss/ws/tools/wsprovide/main/module.xml
+++ b/modules/resources/src/main/resources/modules/wildfly1500/org/jboss/ws/tools/wsprovide/main/module.xml
@@ -34,6 +34,7 @@
     <dependencies>
         <module name="org.jboss.logmanager" services="import"/>
         <module name="org.jboss.ws.tools.common"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
 
 </module>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4145

Follow up of https://github.com/jbossws/jbossws-cxf/pull/42 to ensure all modules definitions for all supported containers have the same dependencies.