### PR TITLE
[JBWS-4156] Get rid of duplicated plugin execution

### DIFF
--- a/modules/testsuite/pom.xml
+++ b/modules/testsuite/pom.xml
@@ -29,7 +29,7 @@
     <gnu.getopt.version>1.0.13</gnu.getopt.version>
     <bc.version>1.60</bc.version>
     <resources-plugin-filters.version>1.1.0.Final</resources-plugin-filters.version>
-    <exec.plugin.version>1.2.1</exec.plugin.version>
+    <exec.plugin.version>1.6.0</exec.plugin.version>
     <port-offset.cxf-tests.jboss>0</port-offset.cxf-tests.jboss>
     <port-offset.cxf-tests.ssl-mutual-auth>5000</port-offset.cxf-tests.ssl-mutual-auth>
     <port-offset.cxf-tests.default-config-tests>10000</port-offset.cxf-tests.default-config-tests>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   <parent>
     <groupId>org.jboss.ws</groupId>
     <artifactId>jbossws-parent</artifactId>
-    <version>1.4.3.Final</version>
+    <version>1.4.4-SNAPSHOT</version>
   </parent>
   
   <!-- Source Control Management -->


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4156

This brings fix for the maven-source-plugin configuration from https://github.com/jbossws/jbossws-parent/pull/4 
**^^^^this needs to be merged first^^^^**

Furthermore, this PR upgrade exec-maven-plugin to the version that is not forking the maven lifecycle (which before the fix resulted in duplicated plugins' execution).