### PR TITLE
[JBWS-4159] Upgrade LittleProxy in TS to 1.1.2

### DIFF
--- a/modules/testsuite/cxf-tests/pom.xml
+++ b/modules/testsuite/cxf-tests/pom.xml
@@ -73,6 +73,31 @@
       <artifactId>junit</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.littleshoot</groupId>
+      <artifactId>littleproxy</artifactId>
+      <version>${org.littleshoot.littleproxy.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.sf.ehcache</groupId>
+          <artifactId>ehcache-core</artifactId>
+        </exclusion>
+        <!-- Let the container messaging subsystem control the Netty dependency version  -->
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <!-- Profiles -->

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/httpproxy/HTTPProxyTestCaseForked.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/httpproxy/HTTPProxyTestCaseForked.java
@@ -62,11 +62,6 @@ import org.littleshoot.proxy.ChainedProxyAdapter;
 import org.littleshoot.proxy.ChainedProxyManager;
 import org.littleshoot.proxy.HttpProxyServer;
 
-import com.barchart.udt.SocketUDT;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 /**
  * Tests / samples for WS client using HTTP Proxy
  * 
@@ -99,11 +94,8 @@ public class HTTPProxyTestCaseForked extends JBossWSTest
    @RunAsClient
    public void testHttpProxy() throws Exception
    {
-      if (checkNativeLibraries()) {
-         initProxyServer();
-      } else {
-         return;
-      }
+      initProxyServer();
+
       final String testHost = "unreachable-testHttpProxy";
       HelloWorld port = getPort(getResourceURL("jaxws/cxf/httpproxy/HelloWorldService.wsdl"), testHost);
       final String hi = "Hi!";
@@ -152,11 +144,8 @@ public class HTTPProxyTestCaseForked extends JBossWSTest
    @RunAsClient
    public void testHttpProxyUsingHTTPClientPolicy() throws Exception
    {
-      if (checkNativeLibraries()) {
-         initProxyServer();
-      } else {
-         return;
-      }
+      initProxyServer();
+
       final String testHost = "unreachable-testHttpProxyUsingHTTPClientPolicy";
       HelloWorld port = getPort(getResourceURL("jaxws/cxf/httpproxy/HelloWorldService.wsdl"), testHost);
       final String hi = "Hi!";
@@ -210,6 +199,11 @@ public class HTTPProxyTestCaseForked extends JBossWSTest
          public boolean authenticate(String user, String pwd)
          {
             return (PROXY_USER.equals(user) && PROXY_PWD.equals(pwd));
+         }
+
+         @Override
+         public String getRealm() {
+            return null;
          }
       };
       InetSocketAddress address = new InetSocketAddress(getServerHost(), ++proxyPort);
@@ -274,11 +268,8 @@ public class HTTPProxyTestCaseForked extends JBossWSTest
    @RunAsClient
    public void testWSDLHttpProxy() throws Exception
    {
-      if (checkNativeLibraries()) {
-         initProxyServer();
-      } else {
-         return;
-      }
+      initProxyServer();
+
       setProxySystemProperties();
       try
       {
@@ -297,11 +288,8 @@ public class HTTPProxyTestCaseForked extends JBossWSTest
    @RunAsClient
    public void testWSDLNoHttpProxy() throws Exception
    {
-      if (checkNativeLibraries()) {
-         initProxyServer();
-      } else {
-         return;
-      }
+      initProxyServer();
+
       clearProxySystemProperties();
       String endpointAddress = "http://unreachable-testWSDLNoHttpProxy" + ENDPOINT_PATH;
       try
@@ -313,20 +301,6 @@ public class HTTPProxyTestCaseForked extends JBossWSTest
       {
          assertTrue(e.getMessage().contains("unreachable-testWSDLNoHttpProxy"));
       }
-   }
-   
-   private boolean checkNativeLibraries() {
-      boolean result;
-      try {
-         result = SocketUDT.INIT_OK;
-      } catch (Throwable e) {
-         result = false;
-      }
-      if (!result) {
-         System.out.println("Native libraries not available or not loadable, skipping test. " +
-         		"Check logs for more details and see https://github.com/adamfisk/LittleProxy/issues/110");
-      }
-      return result;
    }
    
    private static StringBuffer readContent(URL url) throws Exception

--- a/modules/testsuite/pom.xml
+++ b/modules/testsuite/pom.xml
@@ -25,7 +25,7 @@
     <wsdl.publish.location>${project.build.directory}/wsdl-publish</wsdl.publish.location>
     <log4j.output.dir>${project.build.directory}</log4j.output.dir>
     <appclient.output.dir>${project.build.directory}/appclient-logs</appclient.output.dir>
-    <org.littleshoot.littleproxy.version>1.0.0-beta2</org.littleshoot.littleproxy.version>
+    <org.littleshoot.littleproxy.version>1.1.2</org.littleshoot.littleproxy.version>
     <gnu.getopt.version>1.0.13</gnu.getopt.version>
     <bc.version>1.60</bc.version>
     <resources-plugin-filters.version>1.1.0.Final</resources-plugin-filters.version>
@@ -626,31 +626,6 @@
        	  <version>${arquillian.version}</version>
        	  <scope>test</scope>
         </dependency>
-        <!-- LittleProxy depencency declared in this profile as other profiles require different exclusions -->
-        <dependency>
-          <groupId>org.littleshoot</groupId>
-          <artifactId>littleproxy</artifactId>
-          <version>${org.littleshoot.littleproxy.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-api</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>net.sf.ehcache</groupId>
-              <artifactId>ehcache-core</artifactId>
-            </exclusion>
-            <!-- Let the container messaging subsystem control the Netty dependency version  -->
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-all</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
         <dependency>
           <groupId>xerces</groupId>
           <artifactId>xercesImpl</artifactId>
@@ -699,31 +674,6 @@
        	  <version>${arquillian.version}</version>
        	  <scope>test</scope>
         </dependency>
-        <!-- LittleProxy depencency declared in this profile as other profiles require different exclusions -->
-        <dependency>
-          <groupId>org.littleshoot</groupId>
-          <artifactId>littleproxy</artifactId>
-          <version>${org.littleshoot.littleproxy.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-api</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>net.sf.ehcache</groupId>
-              <artifactId>ehcache-core</artifactId>
-            </exclusion>
-            <!-- Let the container messaging subsystem control the Netty dependency version  -->
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-all</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
         <dependency>
           <groupId>xerces</groupId>
           <artifactId>xercesImpl</artifactId>
@@ -771,31 +721,6 @@
        	  <version>${arquillian.version}</version>
        	  <scope>test</scope>
         </dependency>
-        <!-- LittleProxy depencency declared in this profile as other profiles require different exclusions -->
-        <dependency>
-          <groupId>org.littleshoot</groupId>
-          <artifactId>littleproxy</artifactId>
-          <version>${org.littleshoot.littleproxy.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-api</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>net.sf.ehcache</groupId>
-              <artifactId>ehcache-core</artifactId>
-            </exclusion>
-            <!-- Let the container messaging subsystem control the Netty dependency version  -->
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-all</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
         <dependency>
           <groupId>xerces</groupId>
           <artifactId>xercesImpl</artifactId>
@@ -842,31 +767,6 @@
        	  <artifactId>arquillian-protocol-servlet</artifactId>
        	  <version>${arquillian.version}</version>
        	  <scope>test</scope>
-        </dependency>
-        <!-- LittleProxy depencency declared in this profile as other profiles require different exclusions -->
-        <dependency>
-          <groupId>org.littleshoot</groupId>
-          <artifactId>littleproxy</artifactId>
-          <version>${org.littleshoot.littleproxy.version}</version>
-          <exclusions>
-            <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-api</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>net.sf.ehcache</groupId>
-              <artifactId>ehcache-core</artifactId>
-            </exclusion>
-            <!-- Let the container messaging subsystem control the Netty dependency version  -->
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-all</artifactId>
-            </exclusion>
-          </exclusions>
         </dependency>
         <dependency>
           <groupId>xerces</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4159

Upgrade LittleProxy in TS to 1.1.2 and related changes for new version: added new method to override and dropped a workaround, also moved to cxf-tests module as it is used only there.