### PR TITLE
[JBWS-4158] Move to Servlet API 4.0 to be in sync with WildFly

### DIFF
--- a/modules/addons/transports/http/undertow/pom.xml
+++ b/modules/addons/transports/http/undertow/pom.xml
@@ -51,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+      <artifactId>jboss-servlet-api_4.0_spec</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/modules/client/pom.xml
+++ b/modules/client/pom.xml
@@ -205,7 +205,7 @@
     
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+      <artifactId>jboss-servlet-api_4.0_spec</artifactId>
     </dependency>
     
     <!-- [JBWS-3722] Explicit JAXB dependencies to ensure the dependency management from jbossws-cxf pom.xml applies -->
@@ -318,6 +318,7 @@
                         <exclude>org.slf4j:slf4j-jdk14</exclude>
                         <exclude>org.springframework:*</exclude>
                         <exclude>com.sun.xml.bind:*</exclude>
+                        <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude><!-- We want 4.0 API -->
 
                         <!-- We want to use JBoss versions of these APIs -->
                         <exclude>javax.annotation:javax.annotation-api</exclude>

--- a/modules/jaspi/pom.xml
+++ b/modules/jaspi/pom.xml
@@ -21,7 +21,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+      <artifactId>jboss-servlet-api_4.0_spec</artifactId>
     </dependency>
 
     <dependency> <!-- Always make sure jbossws-cxf-factories dependency is explicitly declared before anything transitively pulling CXF -->

--- a/modules/server/pom.xml
+++ b/modules/server/pom.xml
@@ -34,7 +34,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+      <artifactId>jboss-servlet-api_4.0_spec</artifactId>
     </dependency>
     <!-- jbossws dependencies -->
     <dependency>
@@ -306,6 +306,7 @@
                         <exclude>org.slf4j:slf4j-jdk14</exclude>
                         <exclude>org.springframework:*</exclude>
                         <exclude>com.sun.xml.bind:*</exclude>
+                        <exclude>org.jboss.spec.javax.servlet:jboss-servlet-api_3.1_spec</exclude><!-- We want 4.0 API -->
 
                         <!-- We want to use JBoss versions of these APIs -->
                         <exclude>javax.annotation:javax.annotation-api</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <annotation.api.version>1.0.2.Final</annotation.api.version>
     <saaj.api.version>1.0.6.Final</saaj.api.version>
     <saaj.impl.version>1.3.16-jbossorg-1</saaj.impl.version>
-    <servlet.api.version>1.0.2.Final</servlet.api.version>
+    <servlet.api.version>1.0.0.Final</servlet.api.version>
     <stax.api.version>1.0-2</stax.api.version>
     <jms.api.version>1.0.2.Final</jms.api.version>
     <velocity.version>2.0</velocity.version>
@@ -175,36 +175,78 @@
         <groupId>org.jboss.ws</groupId>
         <artifactId>jbossws-wildfly1200-server-integration</artifactId>
         <version>${jbossws.wildfly1200.version}</version>
+        <exclusions>
+          <exclusion><!-- exclude old servlet-api coming from jboss-negotiation-common -->
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jboss.ws</groupId>
         <artifactId>jbossws-wildfly1200-tests-integration</artifactId>
         <version>${jbossws.wildfly1200.version}</version>
+        <exclusions>
+          <exclusion><!-- exclude old servlet-api coming from jboss-negotiation-common -->
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jboss.ws</groupId>
         <artifactId>jbossws-wildfly1300-server-integration</artifactId>
         <version>${jbossws.wildfly1300.version}</version>
+        <exclusions>
+          <exclusion><!-- exclude old servlet-api coming from jboss-negotiation-common -->
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jboss.ws</groupId>
         <artifactId>jbossws-wildfly1300-tests-integration</artifactId>
         <version>${jbossws.wildfly1300.version}</version>
+        <exclusions>
+          <exclusion><!-- exclude old servlet-api coming from jboss-negotiation-common -->
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jboss.ws</groupId>
         <artifactId>jbossws-wildfly1400-server-integration</artifactId>
         <version>${jbossws.wildfly1400.version}</version>
+        <exclusions>
+          <exclusion><!-- exclude old servlet-api coming from jboss-negotiation-common -->
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jboss.ws</groupId>
         <artifactId>jbossws-wildfly1400-tests-integration</artifactId>
         <version>${jbossws.wildfly1400.version}</version>
+        <exclusions>
+          <exclusion><!-- exclude old servlet-api coming from jboss-negotiation-common -->
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-webservices-tests-integration</artifactId>
         <version>${wildfly1400.version}</version>
+        <exclusions>
+          <exclusion><!-- exclude old servlet-api coming from jboss-negotiation-common -->
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.jboss.ws.projects</groupId>
@@ -713,7 +755,7 @@
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.servlet</groupId>
-        <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+        <artifactId>jboss-servlet-api_4.0_spec</artifactId>
         <version>${servlet.api.version}</version>
       </dependency>
       <dependency>
@@ -725,6 +767,12 @@
         <groupId>org.jboss.spec.javax.security.jacc</groupId>
         <artifactId>jboss-jacc-api_1.5_spec</artifactId>
         <version>${jacc.api.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
      
       <!-- jboss provided -->


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4158

Move to Servlet API 4.0 to be in sync with WildFly; necessary excludes provided so that only 4.0 API can be loaded.