### PR TITLE
[JBWS-4182] TS enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The build follows the usual Maven flow; a wilflyXYZ profile has to be specified 
 
 The '-Dserver.home=/foo/bar' option can be used to run the testsuite against a given local server instance; the server must not be already running, as the build will create various standalone server configurations and start multiple instances.
 The '-Dexclude-udp-tests' option can be used to skip UDP tests; that might be needed when running on a network that does not allow UDP broadcast.
+The '-Dexclude-ws-discovery-tests' option can be used to skip WS-Discovery tests; that might be needed when running on a network that does not have set multicast properly.
 The '-Dnodeploy' option can be used to avoid upgrading the ws stack on the target server container.
 The '-Dnoprepare' option can be used to avoid integration tests preparation phase, which includes tuning of the server configurations, wsconsume/wsprovide invocations, etc.
 The '-Ddebug' option can be used to turn on surefire debugging of integration tests only.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The '-Dipv6' option can be used to run the integration testsuite using IPv6 prot
 The '-Darquillian.deploymentExportPath=target/foo' option can be used to have Arquillian write the actual test deployments to disk.
 The '-DnoLogRedirect' can be used to prevent Surefire from redirecting console logs to test output files.
 The '-DenableServerLoggingToConsole' can be used to enable logging of server mesages to console too, otherwise these messages are only redirected to specific log files.
+The '-Dts.dist.dependency.skip' can be used to remove dependency to jbossws-cxf-dist module which makes it possible to run tests directly from testsuite module against arbitrary server given by '-Dserver.home'.
 
 The 'fast' profile can also be used to run tests concurrently; run 'mvn -Pfast,wildflyXYZ post-integration-test' in such case to trigger test servers' shutdown and save memory at the end of each testsuite module.
 

--- a/modules/testsuite/pom.xml
+++ b/modules/testsuite/pom.xml
@@ -921,6 +921,31 @@
     </profile>
 
     <!--
+    Name:  exclude-ws-discovery-tests
+    Descr: Additional exclusions of WS-Discovery tests which require a network environment properly setup for multicast tests
+    -->
+    <profile>
+      <id>exclude-ws-discovery-tests</id>
+      <activation>
+        <property>
+          <name>exclude-ws-discovery-tests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes combine.children="append">
+                <exclude>org/jboss/test/ws/jaxws/samples/wsdd/WSDiscoveryTestCase*</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!--
     Name:  no-jboss-bind-address
     Descr: Set the default jboss.bind.address
 

--- a/modules/testsuite/pom.xml
+++ b/modules/testsuite/pom.xml
@@ -55,13 +55,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency> <!-- dependency to dist module to ensure proper testsuite ordering when running with -T option -->
-      <groupId>org.jboss.ws.cxf</groupId>
-      <artifactId>jbossws-cxf-dist</artifactId>
-      <version>${project.version}</version>
-      <type>pom</type>
-      <scope>provided</scope>
-    </dependency>
     <dependency>
       <groupId>org.jboss.ws</groupId>
       <artifactId>jbossws-common</artifactId>
@@ -436,6 +429,30 @@
         <jboss.home>${project.build.directory}/test-server/jbossws-cxf-dist-${project.version}/wildfly-${jboss.version}</jboss.home>
       </properties>
     </profile>
+
+    <!--
+    Name:  dist-dependency
+    Descr: Add direct jbossws-cxf-dist dependency to ensure proper testsuite ordering in reactor when running with -T option.
+           It may be convenient to drop this dependency when -Dserver.home is given and we are running from testsuite submodule.
+    -->
+    <profile>
+      <id>dist-dependency</id>
+      <activation>
+        <property>
+          <name>!ts.dist.dependency.skip</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.jboss.ws.cxf</groupId>
+          <artifactId>jbossws-cxf-dist</artifactId>
+          <version>${project.version}</version>
+          <type>pom</type>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+      
 
     <!--
     Name:  debug


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4182

This PR adds two enhancements that make it easier to do platform testing:
* ability to skip WS-Discovery tests - not every network has correct setup for WS-Discovery tests
* ability to skip dependency on jbossws-cxf-dist module - it is sometimes convenient to run tests directly from testsuite module against given server but that dist dependency makes that impossible