### PR TITLE
[JBWS-4183] Elytron configuration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ install:
   - java -version; mvn --show-version clean
 script: |
   travis_wait 30 travis-scripts/build-wildfly.sh $BUILD_WFLY_MASTER &&
-  travis_wait 30 travis-scripts/jbossws-test.sh $SERVER_VERSION
+  travis_wait 30 travis-scripts/jbossws-test.sh $SERVER_VERSION $ELYTRON
 
 language: java
 jdk:
@@ -10,9 +10,12 @@ jdk:
   - openjdk11
 
 env:
-  - SERVER_VERSION=wildfly1900 
+  - SERVER_VERSION=wildfly1900
+  - SERVER_VERSION=wildfly1900 ELYTRON=true
   - SERVER_VERSION=wildfly2000
+  - SERVER_VERSION=wildfly2000 ELYTRON=true
   - SERVER_VERSION=wildfly2100 BUILD_WFLY_MASTER=true
+  - SERVER_VERSION=wildfly2100 BUILD_WFLY_MASTER=true ELYTRON=true
 
 cache:
  directories:

--- a/travis-scripts/jbossws-test.sh
+++ b/travis-scripts/jbossws-test.sh
@@ -3,4 +3,5 @@
 set -ex
 
 SERVER_VERSION=$1
-mvn -s .travis-settings.xml -B -V -fae -P${SERVER_VERSION} verify
+ELYTRON=$2
+mvn -s .travis-settings.xml -B -V -fae verify -P${SERVER_VERSION} ${ELYTRON:+-Delytron}


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4183

Several enhancements and fixes are made in this PR, check particular commits.

The main benefit is that travis matrix now contains also combinations with elytron security configuration so that we could catch issues like https://issues.jboss.org/browse/JBWS-4180.
Also its size is reduced from 12 to 10 combinations.
The execution of each combination is now more robust because it has separate timeouts for WildFly build and tests execution.

The other benefit of this PR is that it is easier to test against container with elytron configuration with simply adding `-Delytron` or `-Pelytron` to mvn command safely.

Security manager testing was removed from travis as it needs modifications, see https://issues.jboss.org/browse/JBWS-4184

The travis execution is expected to fail on combinations with `ELYTRON=true` until https://issues.jboss.org/browse/JBWS-4180 is fixed.