### PR TITLE
[JBWS-4187] Allow to parameterize Arquillian startup timeout

### DIFF
--- a/modules/testsuite/cxf-tests/src/test/etc/arquillian.xml
+++ b/modules/testsuite/cxf-tests/src/test/etc/arquillian.xml
@@ -15,6 +15,7 @@
             <!-- AS7-4070 -->
             <property name="waitForPorts">${add_int(port-offset.cxf-tests.jboss,8787)} ${add_int(port-offset.cxf-tests.jboss,9990)}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
+            <property name="startupTimeoutInSeconds">${startupTimeoutInSeconds:60}</property>
         </configuration>
     </container>
     <container qualifier="ssl-mutual-auth" mode="manual">
@@ -29,6 +30,7 @@
             <!-- AS7-4070 -->
             <property name="waitForPorts">${add_int(port-offset.cxf-tests.ssl-mutual-auth,8787)} ${add_int(port-offset.cxf-tests.ssl-mutual-auth,9990)}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
+            <property name="startupTimeoutInSeconds">${startupTimeoutInSeconds:60}</property>
         </configuration>
     </container>
     <container qualifier="default-config-tests" mode="manual">
@@ -43,6 +45,7 @@
             <!-- AS7-4070 -->
             <property name="waitForPorts">${add_int(port-offset.cxf-tests.default-config-tests,8787)} ${add_int(port-offset.cxf-tests.default-config-tests,9990)}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
+            <property name="startupTimeoutInSeconds">${startupTimeoutInSeconds:60}</property>
         </configuration>
     </container>
     <container qualifier="jms">
@@ -57,6 +60,7 @@
             <!-- AS7-4070 -->
             <property name="waitForPorts">${add_int(port-offset.cxf-tests.jms,8787)} ${add_int(port-offset.cxf-tests.jms,9990)}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
+            <property name="startupTimeoutInSeconds">${startupTimeoutInSeconds:60}</property>
         </configuration>
     </container>
   </group>

--- a/modules/testsuite/shared-tests/src/test/etc/arquillian.xml
+++ b/modules/testsuite/shared-tests/src/test/etc/arquillian.xml
@@ -15,6 +15,7 @@
             <!-- AS7-4070 -->
             <property name="waitForPorts">${add_int(port-offset.shared-tests.jboss,8787)} ${add_int(port-offset.shared-tests.jboss,9990)}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
+            <property name="startupTimeoutInSeconds">${startupTimeoutInSeconds:60}</property>
         </configuration>
     </container>
     <container qualifier="default-config-tests" mode="manual">
@@ -29,6 +30,7 @@
             <!-- AS7-4070 -->
             <property name="waitForPorts">${add_int(port-offset.shared-tests.default-config-tests,8787)} ${add_int(port-offset.shared-tests.default-config-tests,9990)}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
+            <property name="startupTimeoutInSeconds">${startupTimeoutInSeconds:60}</property>
         </configuration>
     </container>
     <container qualifier="address-rewrite" mode="manual">
@@ -43,6 +45,7 @@
             <!-- AS7-4070 -->
             <property name="waitForPorts">${add_int(port-offset.shared-tests.address-rewrite,8787)} ${add_int(port-offset.shared-tests.address-rewrite,9990)}</property>
             <property name="waitForPortsTimeoutInSeconds">8</property>
+            <property name="startupTimeoutInSeconds">${startupTimeoutInSeconds:60}</property>
         </configuration>
     </container>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4187

Allow to parameterize Arquillian startup timeout from command line, leaving the default value the same.

One can easily check it is working by executing testsuite with parameter to the command, 
eg. with `-DstartupTimeoutInSeconds=1` one can see container startup will timeout.