### PR TITLE
[JBWS-4183][JBWS-4184] Travis configuration changes and simple elytron profile activation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 install:
-  - mvn clean; java -version
-script:
-  - travis_wait 30 travis-scripts/jbossws-test.sh $SERVER_VERSION $BUILD_WFLY_MASTER
+  - java -version; mvn --show-version clean
+script: |
+  travis_wait 30 travis-scripts/build-wildfly.sh $BUILD_WFLY_MASTER &&
+  travis_wait 30 travis-scripts/jbossws-test.sh $SERVER_VERSION
 
 language: java
 jdk:
@@ -9,8 +10,8 @@ jdk:
   - openjdk11
 
 env:
-  - SERVER_VERSION=wildfly1700 BUILD_WFLY_MASTER=false
-  - SERVER_VERSION=wildfly1800 BUILD_WFLY_MASTER=false
+  - SERVER_VERSION=wildfly1700
+  - SERVER_VERSION=wildfly1800
   - SERVER_VERSION=wildfly1900 BUILD_WFLY_MASTER=true
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 install:
   - mvn clean; java -version
 script:
-  - travis_wait 30 travis-scripts/jbossws-test.sh $SERVER_VERSION $SECURITY_MGR $BUILD_WFLY_MASTER
+  - travis_wait 30 travis-scripts/jbossws-test.sh $SERVER_VERSION $BUILD_WFLY_MASTER
 
 language: java
 jdk:
@@ -9,12 +9,9 @@ jdk:
   - openjdk11
 
 env:
-  - SERVER_VERSION=wildfly1700 SECURITY_MGR=false BUILD_WFLY_MASTER=false
-  - SERVER_VERSION=wildfly1700,secmgr SECURITY_MGR=true BUILD_WFLY_MASTER=false
-  - SERVER_VERSION=wildfly1800 SECURITY_MGR=false BUILD_WFLY_MASTER=false
-  - SERVER_VERSION=wildfly1800,secmgr SECURITY_MGR=true BUILD_WFLY_MASTER=false
-  - SERVER_VERSION=wildfly1900 SECURITY_MGR=false BUILD_WFLY_MASTER=true
-  - SERVER_VERSION=wildfly1900,secmgr SECURITY_MGR=true BUILD_WFLY_MASTER=true
+  - SERVER_VERSION=wildfly1700 BUILD_WFLY_MASTER=false
+  - SERVER_VERSION=wildfly1800 BUILD_WFLY_MASTER=false
+  - SERVER_VERSION=wildfly1900 BUILD_WFLY_MASTER=true
 
 cache:
  directories:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The '-Dnoprepare' option can be used to avoid integration tests preparation phas
 The '-Ddebug' option can be used to turn on surefire debugging of integration tests only.
 The '-Djboss.bind.address=x.y.w.z' option can be used to have the started containers bound to the specified network interface address.
 The '-Dipv6' option can be used to run the integration testsuite using IPv6 protocol.
+The '-Delytron' option can be used to run the integration testsuite against container with Elytron security configuration.
 The '-Darquillian.deploymentExportPath=target/foo' option can be used to have Arquillian write the actual test deployments to disk.
 The '-DnoLogRedirect' can be used to prevent Surefire from redirecting console logs to test output files.
 The '-DenableServerLoggingToConsole' can be used to enable logging of server mesages to console too, otherwise these messages are only redirected to specific log files.

--- a/modules/testsuite/pom.xml
+++ b/modules/testsuite/pom.xml
@@ -19,6 +19,7 @@
     <surefire.memory.args>-Xmx640m</surefire.memory.args>
     <surefire.jdwp.args>-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005</surefire.jdwp.args>
     <surefire.management.args>-Dcom.sun.management.jmxremote</surefire.management.args>
+    <additionalGroovyScriptSuffix />
     <test.archive.directory>${project.build.directory}/test-libs</test.archive.directory>
     <test.classes.directory>${project.build.directory}/test-classes</test.classes.directory>
     <test.resources.directory>${project.build.directory}/test-resources</test.resources.directory>
@@ -795,6 +796,22 @@
           <artifactId>xercesImpl</artifactId>
         </dependency>
       </dependencies>
+    </profile>
+
+    <!--
+    Name:  elytron
+    Descr: Run tests against container with elytron security set instead of the legacy one
+    -->
+    <profile>
+      <id>elytron</id>
+      <activation>
+        <property>
+          <name>elytron</name>
+        </property>
+      </activation>
+      <properties>
+        <additionalGroovyScriptSuffix>-elytron</additionalGroovyScriptSuffix>
+      </properties>
     </profile>
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -1054,7 +1054,6 @@
         <jboss.home>${server.home}</jboss.home>
         <jboss.version>${wildfly1600.version}</jboss.version>
         <additionalJvmArgs>${ipVerArgs} ${modular.jdk.props} ${modular.jdk.args}</additionalJvmArgs>
-        <additionalGroovyScriptSuffix />
       </properties>
       <modules>
         <module>modules/dist</module>
@@ -1072,7 +1071,6 @@
         <jboss.home>${server.home}</jboss.home>
         <jboss.version>${wildfly1700.version}</jboss.version>
         <additionalJvmArgs>${ipVerArgs} ${modular.jdk.props} ${modular.jdk.args}</additionalJvmArgs>
-        <additionalGroovyScriptSuffix />
       </properties>
       <modules>
         <module>modules/dist</module>
@@ -1091,7 +1089,6 @@
         <jboss.home>${server.home}</jboss.home>
         <jboss.version>${wildfly1800.version}</jboss.version>
         <additionalJvmArgs>${ipVerArgs} ${modular.jdk.props} ${modular.jdk.args}</additionalJvmArgs>
-        <additionalGroovyScriptSuffix />
       </properties>
       <modules>
         <module>modules/dist</module>
@@ -1110,19 +1107,11 @@
         <jboss.home>${server.home}</jboss.home>
         <jboss.version>${wildfly1900.version}</jboss.version>
         <additionalJvmArgs>${ipVerArgs} ${modular.jdk.props} ${modular.jdk.args}</additionalJvmArgs>
-        <additionalGroovyScriptSuffix />
       </properties>
       <modules>
         <module>modules/dist</module>
         <module>modules/testsuite</module>
       </modules>
-    </profile>
-
-    <profile>
-      <id>elytron</id>
-      <properties>
-        <additionalGroovyScriptSuffix>-elytron</additionalGroovyScriptSuffix>
-      </properties>
     </profile>
 
     <profile>

--- a/travis-scripts/build-wildfly.sh
+++ b/travis-scripts/build-wildfly.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -ex
+
+# uncomment to debug on non zero exit; be sure to print the correct log file
+#function finish {
+#  if [[ $BUILD_WFLY_MASTER = "true" ]]; then
+#     WFLY_TARGET="$TRAVIS_HOME/wildfly/dist/target/"
+#     WFLY_HOME=$(find $WFLY_TARGET -name \wildfly\* -type d -maxdepth 1 -print | head -n1)
+#     echo "############ ERROR  dumping server.log #####################"
+#     cat $WFLY_HOME"/standalone/log/server.log"
+#  fi
+#}
+#
+#trap finish EXIT
+
+BUILD_WFLY_MASTER=$1
+if [[ "$BUILD_WFLY_MASTER" = "true" ]]; then
+
+  rm -rf data
+  # We must clone wildfly outside of project root dir so that maven doesn't complain about unexpected parent project
+  git clone --depth=1 --branch=master https://github.com/wildfly/wildfly.git $TRAVIS_HOME/wildfly
+  pushd $TRAVIS_HOME/wildfly
+  # Compile in silence. The build output is too much for travis log
+  mvn -s $TRAVIS_BUILD_DIR/.travis-settings.xml --quiet clean install -DskipTests -Denforcer.skip -Dcheckstyle.skip -Prelease
+  popd
+fi

--- a/travis-scripts/jbossws-test.sh
+++ b/travis-scripts/jbossws-test.sh
@@ -1,36 +1,6 @@
 #!/bin/bash
 
-set -ev
-java -version
-
-# uncomment to debug on non zero exit; be sure to print the correct log file
-#function finish {
-#  if [[ $USE_WFLY_MASTER = "true" ]]; then
-#     WFLY_TARGET=`pwd`"/wfly/wildfly/dist/target/"
-#     WFLY_HOME=$(find $WFLY_TARGET -name \wildfly\* -type d -maxdepth 1 -print | head -n1)
-#     echo "############ ERROR  dumping server.log #####################"
-#     cat $WFLY_HOME"/standalone/log/server.log"
-#  fi
-#}
-#
-#trap finish EXIT
-
+set -ex
 
 SERVER_VERSION=$1
-USE_WFLY_MASTER=$2
-if [[ $USE_WFLY_MASTER = "true" ]]; then
-
-  MYPWD=`pwd`
-
-  rm -rf wfly
-  mkdir wfly
-  cd wfly
-  git clone https://github.com/wildfly/wildfly.git
-  cd wildfly
-
-  # compile in silence.  The bld output is too much for travis log
-  mvn --quiet clean install -DskipTests -Denforcer.skip -Dcheckstyle.skip -Prelease
-  cd $MYPWD
-fi
-mvn -s .travis-settings.xml -B -fae -P${SERVER_VERSION} integration-test
-
+mvn -s .travis-settings.xml -B -V -fae -P${SERVER_VERSION} verify

--- a/travis-scripts/jbossws-test.sh
+++ b/travis-scripts/jbossws-test.sh
@@ -17,8 +17,7 @@ java -version
 
 
 SERVER_VERSION=$1
-SECURITY_MGR=$2
-USE_WFLY_MASTER=$3
+USE_WFLY_MASTER=$2
 if [[ $USE_WFLY_MASTER = "true" ]]; then
 
   MYPWD=`pwd`
@@ -33,5 +32,5 @@ if [[ $USE_WFLY_MASTER = "true" ]]; then
   mvn --quiet clean install -DskipTests -Denforcer.skip -Dcheckstyle.skip -Prelease
   cd $MYPWD
 fi
-mvn -s .travis-settings.xml -B -fae -DSECMGR=${SECURITY_MGR} -P${SERVER_VERSION} integration-test
+mvn -s .travis-settings.xml -B -fae -P${SERVER_VERSION} integration-test
 


### PR DESCRIPTION
https://issues.jboss.org/browse/JBWS-4184
https://issues.jboss.org/browse/JBWS-4183

This is part of https://github.com/jbossws/jbossws-cxf/pull/112, particularly:

Security manager testing was removed from travis as it needs modifications, see https://issues.jboss.org/browse/JBWS-4184

The combination matrix is reduced and also fixed (one don't want to use `BUILD_WFLY_MASTER=true` with released container version).

The execution of each combination is now more robust because it has separate timeouts for WildFly build and tests execution.

The other benefit of this PR is that it is easier to test against container with elytron configuration with simply adding -Delytron or -Pelytron to mvn command safely.