### PR TITLE
[JBWS-4221] SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate) on IBM JDK after ELY-2026

### DIFF
--- a/modules/testsuite/cxf-tests/src/test/resources/jaxws/cxf/clientConfig/META-INF/wildfly-config-ssl-context.xml
+++ b/modules/testsuite/cxf-tests/src/test/resources/jaxws/cxf/clientConfig/META-INF/wildfly-config-ssl-context.xml
@@ -18,6 +18,7 @@
                 <key-store-ssl-certificate key-store-name="keystore" alias="client">
                     <key-store-clear-password password="changeit"/>
                 </key-store-ssl-certificate>
+                <protocol names="TLSv1.2"/>
             </ssl-context>
         </ssl-contexts>
         <ssl-context-rules>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBWS-4221