### PR TITLE
[JBWS-4133] Use reflection to check if a Principal is a Group

### DIFF
--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/security/authentication/SubjectCreatingInterceptor.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/security/authentication/SubjectCreatingInterceptor.java
@@ -22,7 +22,6 @@
 package org.jboss.wsf.stack.cxf.security.authentication;
 
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -60,6 +59,21 @@ import org.jboss.wsf.stack.cxf.security.nonce.NonceStore;
  */
 public class SubjectCreatingInterceptor extends WSS4JInInterceptor
 {
+    private static final Class<?> groupClass;
+
+    static
+    {
+        Class<?> clazz = null;
+        try
+        {
+            clazz = Class.forName("java.security.acl.Group");
+        } catch (Throwable t)
+        {
+            // ignore
+        }
+        groupClass = clazz;
+    }
+
    protected final SubjectCreator helper = new SubjectCreator();
 
    private static final Logger LOG = Logger.getLogger(SubjectCreatingInterceptor.class);
@@ -171,7 +185,7 @@ public class SubjectCreatingInterceptor extends WSS4JInInterceptor
    private boolean checkUserPrincipal(Set<Principal> principals, String name)
    {
       for (Principal p : principals) {
-         if (!(p instanceof Group)) {
+         if (groupClass == null || !groupClass.isInstance(p)) {
             return p.getName().equals(name);
          }
       }

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/security/authentication/SubjectCreatingPolicyInterceptor.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/security/authentication/SubjectCreatingPolicyInterceptor.java
@@ -22,7 +22,6 @@
 package org.jboss.wsf.stack.cxf.security.authentication;
 
 import java.security.Principal;
-import java.security.acl.Group;
 import java.util.Set;
 
 import javax.security.auth.Subject;
@@ -53,6 +52,21 @@ import org.jboss.wsf.stack.cxf.security.nonce.NonceStore;
  */
 public class SubjectCreatingPolicyInterceptor extends AbstractPhaseInterceptor<Message>
 {
+   private static final Class<?> groupClass;
+
+   static
+   {
+      Class<?> clazz = null;
+      try
+      {
+         clazz = Class.forName("java.security.acl.Group");
+      } catch (Throwable t)
+      {
+         // ignore
+      }
+      groupClass = clazz;
+   }
+
    protected final SubjectCreator helper = new SubjectCreator();
 
    public SubjectCreatingPolicyInterceptor()
@@ -149,7 +163,7 @@ public class SubjectCreatingPolicyInterceptor extends AbstractPhaseInterceptor<M
       if (!principals.isEmpty())
       {
           Principal principal = principals.iterator().next();
-          if (!(principal instanceof Group))
+          if (groupClass == null || !groupClass.isInstance(principal))
           {
               return principal;
           }


### PR DESCRIPTION
This approach relies on the fact that the first Principal in a subject will represent the caller's identity.
The code already assumes that the first non-Group Principal is that, so this is not a new assumption.
Code that populates a Subject that cannot use Group must ensure that whatever principal represents the security identity gets added first.

Issue: https://issues.redhat.com/browse/JBWS-4133