### PR TITLE
[JBWS-4235] Updating test accordingly to pass with both Woodstox on WildFly25 and JDK JAXP impl on WildFly26

### DIFF
--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws3628/JBWS3628TestCase.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws3628/JBWS3628TestCase.java
@@ -83,7 +83,7 @@ public class JBWS3628TestCase extends JBossWSTest
    
    private void checkPolicyReference(URL wsdlURL, String refId) throws Exception {
       final String wsdl = IOUtils.readAndCloseStream(wsdlURL.openStream());
-      assertTrue("WSDL does not contain policy reference to '" + refId + "'", wsdl.contains("<wsp:PolicyReference URI=\"#" + refId + "\"/>"));
+      assertTrue("WSDL does not contain policy reference to '" + refId + "'", wsdl.contains("<wsp:PolicyReference URI=\"#" + refId + "\""));
    }
    
 }

--- a/modules/testsuite/pom.xml
+++ b/modules/testsuite/pom.xml
@@ -810,7 +810,6 @@
                 <exclude>org/jboss/test/ws/jaxws/cxf/clientConfig/SSLContextElytronClientConfigTestCaseForked*</exclude>
                 <exclude>org/jboss/test/ws/publish/EndpointPublishTestCase*</exclude>
                 <!--https://issues.redhat.com/browse/WFLY-15563 -->
-                <exclude>org/jboss/test/ws/jaxws/cxf/jbws3628/JBWS3628TestCase*</exclude>
                 <exclude>org/jboss/test/ws/jaxws/samples/provider/ProviderJAXBTestCase*</exclude>
                 <exclude>org/jboss/test/ws/jaxws/samples/httpbinding/HttpJAXBTestCase*</exclude>
               </excludes>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBWS-4235