### PR TITLE
Use com.sun.activation:jakarta-activation

### DIFF
--- a/modules/testsuite/cxf-tests/pom.xml
+++ b/modules/testsuite/cxf-tests/pom.xml
@@ -21,8 +21,8 @@
 
   <dependencies>
      <dependency>
-        <groupId>jakarta.activation</groupId>
-        <artifactId>jakarta.activation-api</artifactId>
+        <groupId>com.sun.activation</groupId>
+        <artifactId>jakarta.activation</artifactId>
      </dependency>
      <dependency>
         <groupId>jakarta.xml.ws</groupId>

--- a/modules/testsuite/shared-tests/pom.xml
+++ b/modules/testsuite/shared-tests/pom.xml
@@ -16,8 +16,8 @@
   <!-- Dependencies -->
   <dependencies>
      <dependency>
-        <groupId>jakarta.activation</groupId>
-        <artifactId>jakarta.activation-api</artifactId>
+        <groupId>com.sun.activation</groupId>
+        <artifactId>jakarta.activation</artifactId>
      </dependency>
      <dependency>
         <groupId>com.sun.mail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <commons.logging.version>1.2</commons.logging.version>
     <log4j.version>1.2.17</log4j.version>
     <org.slf4j.version>1.7.25</org.slf4j.version>
-    <activation.version>1.1.1</activation.version>
+    <activation.version>2.0.1</activation.version>
     <fastinfoset.version>1.2.16</fastinfoset.version>
     <neethi.version>3.1.1</neethi.version>
     <opensaml.version>4.0.1</opensaml.version>
@@ -605,6 +605,12 @@
             <artifactId>jaxws-api</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>com.sun.activation</groupId>
+        <artifactId>jakarta.activation</artifactId>
+        <version>${activation.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Explicitly set dependency on com.sun.activation:jakarta-activation, which include implementations of providers required for dealing with attachments, etc.