### PR TITLE
Jakarta jaxbintros

### DIFF
--- a/modules/testsuite/cxf-tests/pom.xml
+++ b/modules/testsuite/cxf-tests/pom.xml
@@ -21,8 +21,8 @@
 
   <dependencies>
      <dependency>
-        <groupId>jakarta.activation</groupId>
-        <artifactId>jakarta.activation-api</artifactId>
+        <groupId>com.sun.activation</groupId>
+        <artifactId>jakarta.activation</artifactId>
      </dependency>
      <dependency>
         <groupId>jakarta.xml.ws</groupId>

--- a/modules/testsuite/pom.xml
+++ b/modules/testsuite/pom.xml
@@ -909,9 +909,9 @@
 
                 <!-- https://issues.redhat.com/browse/JBWS-4261 -->
                 <exclude>org.jboss.jaxbintros related NoClassDefFoundError*</exclude>
-                <exclude>org/jboss/test/ws/jaxws/cxf/jaxbintros/JAXBIntroTestCase*</exclude>
+		<!--                <exclude>org/jboss/test/ws/jaxws/cxf/jaxbintros/JAXBIntroTestCase*</exclude>
                 <exclude>org/jboss/test/ws/jaxws/samples/jaxbintros/JAXBIntroTestCase*</exclude>
-                <exclude>org/jboss/test/ws/jaxws/samples/jaxbintros/AnnotationReaderTestCase*</exclude>
+		<exclude>org/jboss/test/ws/jaxws/samples/jaxbintros/AnnotationReaderTestCase*</exclude> -->
                 <exclude>org/jboss/test/ws/jaxws/jbws1809/JBWS1809TestCase*</exclude>
 
                 <!-- https://issues.redhat.com/browse/JBWS-4262   -->

--- a/modules/testsuite/shared-tests/pom.xml
+++ b/modules/testsuite/shared-tests/pom.xml
@@ -16,8 +16,8 @@
   <!-- Dependencies -->
   <dependencies>
      <dependency>
-        <groupId>jakarta.activation</groupId>
-        <artifactId>jakarta.activation-api</artifactId>
+        <groupId>com.sun.activation</groupId>
+        <artifactId>jakarta.activation</artifactId>
      </dependency>
      <dependency>
         <groupId>com.sun.mail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <jboss.modules.version>2.0.2.Final</jboss.modules.version>
     <jbossws.api.version>2.0.0.Final</jbossws.api.version>
     <jbossws.spi.version>4.0.1-SNAPSHOT</jbossws.spi.version>
-    <jbossws.common.version>4.0.0.Final</jbossws.common.version>
+    <jbossws.common.version>4.0.1-SNAPSHOT</jbossws.common.version>
     <jbossws.common.tools.version>1.3.3-SNAPSHOT</jbossws.common.tools.version>
     <wildfly2500.version>25.0.0.Final</wildfly2500.version>
     <wildfly2600.version>26.0.0.Final</wildfly2600.version>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <commons.logging.version>1.2</commons.logging.version>
     <log4j.version>1.2.17</log4j.version>
     <org.slf4j.version>1.7.25</org.slf4j.version>
-    <activation.version>1.1.1</activation.version>
+    <activation.version>2.0.1</activation.version>
     <fastinfoset.version>1.2.16</fastinfoset.version>
     <neethi.version>3.1.1</neethi.version>
     <opensaml.version>4.0.1</opensaml.version>
@@ -605,6 +605,12 @@
             <artifactId>jaxws-api</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>com.sun.activation</groupId>
+        <artifactId>jakarta.activation</artifactId>
+        <version>${activation.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Restoring jaxbintros functionalities. This depends on https://github.com/jbossws/jbossws-common/pull/25 , which in turns requires building jboss.jaxbintros:jboss-jaxb-intros:jar:2.0.0-SNAPSHOT (we might want to release this, as we know the tests are passing now...).
Note this also includes the contents of https://github.com/jbossws/jbossws-cxf/pull/192