### PR TITLE
Add testsuite support for jdk17.

### DIFF
--- a/modules/testsuite/cxf-tests/src/test/etc/arquillian.xml
+++ b/modules/testsuite/cxf-tests/src/test/etc/arquillian.xml
@@ -6,7 +6,7 @@
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">-server -Xms64m -Xmx512m -Djboss.socket.binding.port-offset=${port-offset.cxf-tests.jboss} ${additionalJvmArgs}</property>
+            <property name="javaVmArguments">-server -Xms64m -Xmx512m -Djboss.socket.binding.port-offset=${port-offset.cxf-tests.jboss} ${additionalJvmArgs} ${server.jvm.jpms.args}</property>
             <property name="serverConfig">jbws-testsuite-default.xml</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${jboss.bind.address:localhost}</property>
@@ -21,7 +21,7 @@
     <container qualifier="ssl-mutual-auth" mode="manual">
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">-server -Xms48m -Xmx384m -Djboss.socket.binding.port-offset=${port-offset.cxf-tests.ssl-mutual-auth} ${additionalJvmArgs}</property>
+            <property name="javaVmArguments">-server -Xms48m -Xmx384m -Djboss.socket.binding.port-offset=${port-offset.cxf-tests.ssl-mutual-auth} ${additionalJvmArgs} ${server.jvm.jpms.args}</property>
             <property name="serverConfig">jbws-testsuite-ssl-mutual-auth.xml</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${jboss.bind.address:localhost}</property>
@@ -36,7 +36,7 @@
     <container qualifier="default-config-tests" mode="manual">
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">-server -Xms48m -Xmx384m -Djboss.socket.binding.port-offset=${port-offset.cxf-tests.default-config-tests} ${additionalJvmArgs}</property>
+            <property name="javaVmArguments">-server -Xms48m -Xmx384m -Djboss.socket.binding.port-offset=${port-offset.cxf-tests.default-config-tests} ${additionalJvmArgs} ${server.jvm.jpms.args}</property>
             <property name="serverConfig">jbws-testsuite-default-config-tests.xml</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${jboss.bind.address:localhost}</property>
@@ -51,7 +51,7 @@
     <container qualifier="jms">
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">-server -Xms48m -Xmx384m -Djboss.socket.binding.port-offset=${port-offset.cxf-tests.jms} ${additionalJvmArgs}</property>
+            <property name="javaVmArguments">-server -Xms48m -Xmx384m -Djboss.socket.binding.port-offset=${port-offset.cxf-tests.jms} ${additionalJvmArgs} ${server.jvm.jpms.args}</property>
             <property name="serverConfig">jbws-testsuite-jms.xml</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${jboss.bind.address:localhost}</property>

--- a/modules/testsuite/pom.xml
+++ b/modules/testsuite/pom.xml
@@ -38,6 +38,9 @@
     <port-offset.shared-tests.default-config-tests>20000</port-offset.shared-tests.default-config-tests>
     <port-offset.shared-tests.address-rewrite>25000</port-offset.shared-tests.address-rewrite>
     <port-offset.perf-tests.jboss>30000</port-offset.perf-tests.jboss>
+
+    <server.jvm.jpms.args>--add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED</server.jvm.jpms.args>
+    <client.jvm.jpms.args>--add-exports=java.desktop/sun.awt=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.management/javax.management=ALL-UNNAMED --add-opens=java.naming/javax.naming=ALL-UNNAMED</client.jvm.jpms.args>
   </properties>
 
   <!-- Modules -->
@@ -259,7 +262,10 @@
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${surefire.jvm.args} ${surefire.jvm.management.args} ${surefire.default-mgmt-serurity.args} ${ipVerArgs}</argLine>
+          <systemPropertyVariables>
+            <server.jvm.jpms.args>${server.jvm.jpms.args}</server.jvm.jpms.args>
+          </systemPropertyVariables>
+          <argLine>${surefire.jvm.args} ${surefire.jvm.management.args} ${surefire.default-mgmt-serurity.args} ${ipVerArgs} ${client.jvm.jpms.args} -Dlauncher.skip.jpms.properties=true</argLine>
           <skip>true</skip>
           <failIfNoTests>false</failIfNoTests>
           <runOrder>alphabetical</runOrder>

--- a/modules/testsuite/shared-tests/src/test/etc/arquillian.xml
+++ b/modules/testsuite/shared-tests/src/test/etc/arquillian.xml
@@ -6,7 +6,7 @@
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">-server -Xms64m -Xmx512m -Djboss.socket.binding.port-offset=${port-offset.shared-tests.jboss} ${additionalJvmArgs}</property>
+            <property name="javaVmArguments">-server -Xms64m -Xmx512m -Djboss.socket.binding.port-offset=${port-offset.shared-tests.jboss} ${additionalJvmArgs} ${server.jvm.jpms.args}</property>
             <property name="serverConfig">jbws-testsuite-shared-default.xml</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${jboss.bind.address:localhost}</property>
@@ -21,7 +21,7 @@
     <container qualifier="default-config-tests" mode="manual">
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">-server -Xms48m -Xmx384m -Djboss.socket.binding.port-offset=${port-offset.shared-tests.default-config-tests} ${additionalJvmArgs}</property>
+            <property name="javaVmArguments">-server -Xms48m -Xmx384m -Djboss.socket.binding.port-offset=${port-offset.shared-tests.default-config-tests} ${additionalJvmArgs} ${server.jvm.jpms.args}</property>
             <property name="serverConfig">jbws-testsuite-shared-default-config-tests.xml</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${jboss.bind.address:localhost}</property>
@@ -36,7 +36,7 @@
     <container qualifier="address-rewrite" mode="manual">
         <configuration>
             <property name="jbossHome">${jboss.home}</property>
-            <property name="javaVmArguments">-server -Xms32m -Xmx256m -Djboss.socket.binding.port-offset=${port-offset.shared-tests.address-rewrite} ${additionalJvmArgs}</property>
+            <property name="javaVmArguments">-server -Xms32m -Xmx256m -Djboss.socket.binding.port-offset=${port-offset.shared-tests.address-rewrite} ${additionalJvmArgs} ${server.jvm.jpms.args}</property>
             <property name="serverConfig">jbws-testsuite-shared-address-rewrite.xml</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${jboss.bind.address:localhost}</property>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <shrinkwrap.version>1.2.6</shrinkwrap.version>
     <derby.version>10.14.2.0</derby.version>
     <arquillian.version>1.4.0.Final</arquillian.version>
-    <arquillian-wildfly-container.version>2.2.0.Final</arquillian-wildfly-container.version>
+    <arquillian-wildfly-container.version>5.0.0.Alpha2</arquillian-wildfly-container.version>
     <version.commons.validator>1.6</version.commons.validator>
     <interceptor.api.version>2.0.0.Final</interceptor.api.version>
     <version.org.jboss.openjdk-orb>8.1.5.Final</version.org.jboss.openjdk-orb>
@@ -118,7 +118,7 @@
     <jacc.api.version>1.0.2.Final</jacc.api.version>
     <javax.inject.version>1</javax.inject.version>
     <org.easymock.version>3.2</org.easymock.version>
-    <junit.version>4.12</junit.version>
+    <junit.version>4.13.2</junit.version>
     <eclipse.plugin.version>1.0.0</eclipse.plugin.version>
     <gmavenplus.version>1.5</gmavenplus.version>
     <groovy.version>2.4.15</groovy.version>


### PR DESCRIPTION
Hi, this PR adding support for jdk 17 which newer wildfly start supporting. Mainly it adding jpms properties which is used [https://github.com/wildfly/wildfly-core/blob/19.0.0.Beta7/core-feature-pack/common/src/main/resources/content/bin/common.sh#L39-L60](https://github.com/wildfly/wildfly-core/blob/19.0.0.Beta7/core-feature-pack/common/src/main/resources/content/bin/common.sh#L39-L60)