### PR TITLE
[JBEAP-19218]:JBossWS/CXF is using application's JAXP instead of the …

### DIFF
--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/JAXPDelegateClassLoader.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/JAXPDelegateClassLoader.java
@@ -1,0 +1,107 @@
+package org.jboss.wsf.stack.cxf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.SecureClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import org.jboss.ws.common.utils.DelegateClassLoader;
+
+public class JAXPDelegateClassLoader extends DelegateClassLoader
+{
+    private final ClassLoader delegate;
+
+    private final ClassLoader parent;
+    private static Set<String> skipSps = new HashSet<String>(Arrays. asList(
+            "META-INF/services/javax.xml.parsers.DocumentBuilderFactory",
+            "META-INF/services/javax.xml.parsers.SAXParserFactory",
+            "META-INF/services/javax.xml.validation.SchemaFactory",
+            "META-INF/services/javax.xml.stream.XMLEventFactory",
+            "META-INF/services/javax.xml.datatype.DatatypeFactory",
+            "META-INF/services/javax.xml.transform.TransformerFactory",
+            "META-INF/services/javax.xml.xpath.XPathFactory"
+    ));
+
+    public JAXPDelegateClassLoader(final ClassLoader delegate, final ClassLoader parent)
+    {
+        super(delegate, parent);
+        this.delegate = delegate;
+        this.parent = parent;
+    }
+
+    @Override
+    public URL getResource(final String name)
+    {
+        URL url = null;
+        if (parent != null)
+        {
+            url = parent.getResource(name);
+        }
+        return (url == null && !skipSps.contains(name)) ? delegate.getResource(name) : url;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Enumeration<URL> getResources(final String name) throws IOException
+    {
+        final ArrayList<Enumeration<URL>> foundResources = new ArrayList<Enumeration<URL>>();
+
+        if (!skipSps.contains(name)) {
+            foundResources.add(delegate.getResources(name));
+        }
+        if (parent != null)
+        {
+            foundResources.add(parent.getResources(name));
+        }
+
+        return new Enumeration<URL>()
+        {
+            private int position = foundResources.size() - 1;
+
+            public boolean hasMoreElements()
+            {
+                while (position >= 0)
+                {
+                    if (foundResources.get(position).hasMoreElements())
+                    {
+                        return true;
+                    }
+                    position--;
+                }
+                return false;
+            }
+
+            public URL nextElement()
+            {
+                while (position >= 0)
+                {
+                    try
+                    {
+                        return (foundResources.get(position)).nextElement();
+                    }
+                    catch (NoSuchElementException e)
+                    {
+                    }
+                    position--;
+                }
+                throw new NoSuchElementException();
+            }
+        };
+    }
+
+    @Override
+    public InputStream getResourceAsStream(final String name)
+    {
+        InputStream is = null;
+        if (parent != null)
+        {
+            is = parent.getResourceAsStream(name);
+        }
+        return (is == null && !skipSps.contains(name)) ? delegate.getResourceAsStream(name) : is;
+    }
+}

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/SecurityActions.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/SecurityActions.java
@@ -79,21 +79,22 @@ class SecurityActions
          });
       }
    }
-   static DelegateClassLoader createDelegateClassLoader(final ClassLoader delegate, final ClassLoader parent)
+   
+   static JAXPDelegateClassLoader createDelegateClassLoader(final ClassLoader delegate, final ClassLoader parent)
    {
       SecurityManager sm = System.getSecurityManager();
       if (sm == null)
       {
-         return new DelegateClassLoader(delegate, parent);
+         return new JAXPDelegateClassLoader(delegate, parent);
       }
       else
       {
-         return AccessController.doPrivileged(new PrivilegedAction<DelegateClassLoader>()
+         return AccessController.doPrivileged(new PrivilegedAction<JAXPDelegateClassLoader>()
          {
             @Override
-            public DelegateClassLoader run()
+            public JAXPDelegateClassLoader run()
             {
-               return new DelegateClassLoader(delegate, parent);
+               return new JAXPDelegateClassLoader(delegate, parent);
             }
          });
       }

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/deployment/aspect/BusDeploymentAspect.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/deployment/aspect/BusDeploymentAspect.java
@@ -32,7 +32,7 @@ import org.jboss.wsf.spi.deployment.ArchiveDeployment;
 import org.jboss.wsf.spi.deployment.Deployment;
 import org.jboss.wsf.spi.deployment.ResourceResolver;
 import org.jboss.wsf.spi.metadata.webservices.JBossWebservicesMetaData;
-
+import org.jboss.wsf.stack.cxf.JAXPDelegateClassLoader;
 import org.jboss.wsf.stack.cxf.client.configuration.JBossWSBusFactory;
 import org.jboss.wsf.stack.cxf.configuration.BusHolder;
 import org.jboss.wsf.stack.cxf.deployment.WSDLFilePublisher;
@@ -90,7 +90,7 @@ public final class BusDeploymentAspect extends AbstractDeploymentAspect
          //use origClassLoader (which on AS7 is set to ASIL aggregation module's classloader by TCCLDeploymentProcessor) as
          //parent to make sure user provided libs in the deployment do no mess up the WS endpoint's deploy if they duplicates
          //libraries already available on the application server modules.
-         SecurityActions.setContextClassLoader(new DelegateClassLoader(dep.getClassLoader(), origClassLoader));
+         SecurityActions.setContextClassLoader(new JAXPDelegateClassLoader(dep.getClassLoader(), origClassLoader));
          DDBeans metadata = dep.getAttachment(DDBeans.class);
          BusHolder holder = new BusHolder(metadata);
 

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4385/HelloBean.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4385/HelloBean.java
@@ -1,6 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.jboss.test.ws.jaxws.cxf.jbws4385;
-
-
 import javax.xml.parsers.DocumentBuilderFactory;
 
 @javax.jws.WebService(targetNamespace = "http://test.ws.jboss.org/",

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4385/JBWS4385TestCase.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4385/JBWS4385TestCase.java
@@ -1,5 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.jboss.test.ws.jaxws.cxf.jbws4385;
-
 import javax.xml.ws.Service;
 import java.io.File;
 import java.net.URL;


### PR DESCRIPTION
…container's JAXP implementation; This fix starts with Brad Maxwell's proposed change and added a JAXPDelegateClassLoader to Protect the jbossws runtime from loading the jaxp impl from user's deployment