### PR TITLE
[5.4.x branch][JBWS-4429] NPE when SOAP request with mismatched targetNameSpace is received

### DIFF
--- a/modules/client/src/main/java/org/jboss/wsf/stack/cxf/i18n/Messages.java
+++ b/modules/client/src/main/java/org/jboss/wsf/stack/cxf/i18n/Messages.java
@@ -225,4 +225,7 @@ public interface Messages {
 
     @Message(id = 24113, value = "Invalid endpoint URI: %s")
     IllegalArgumentException invalidEndpointURI(String endpoint);
+
+    @Message(id = 24118, value = "BindingOperation is missing for authorization")
+    IllegalArgumentException missingBindingOperationForAuthorization();
 }

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/HandlerAuthInterceptor.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/HandlerAuthInterceptor.java
@@ -147,6 +147,10 @@ public class HandlerAuthInterceptor extends AbstractPhaseInterceptor<Message>
             SecurityContext secCtx = message.get(SecurityContext.class);
             BindingOperationInfo bop = exchange.getBindingOperationInfo();
             MethodDispatcher md = (MethodDispatcher) exchange.getService().get(MethodDispatcher.class.getName());
+            if (bop == null)
+            {
+               throw MESSAGES.missingBindingOperationForAuthorization();
+            }
             Method method = md.getMethod(bop);
 
             EJBMethodSecurityAttribute attributes = attributeProvider.getSecurityAttributes(method);

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/HelloService.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/HelloService.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.test.ws.jaxws.cxf.jbws4429;
+
+import jakarta.jws.WebMethod;
+import jakarta.jws.WebParam;
+import jakarta.jws.WebResult;
+import jakarta.jws.WebService;
+import jakarta.xml.bind.annotation.XmlSeeAlso;
+import jakarta.xml.ws.RequestWrapper;
+import jakarta.xml.ws.ResponseWrapper;
+
+@WebService(name = "HelloServiceService", targetNamespace = "http://com.redhat.gss.example.soap/")
+@XmlSeeAlso({
+        ObjectFactory.class
+})
+public interface HelloService {
+
+    @WebMethod
+    @WebResult(targetNamespace = "")
+    @RequestWrapper(localName = "sayHello", targetNamespace = "http://com.redhat.gss.example.soap/",
+            className = "org.jboss.test.ws.jaxws.cxf.jbws4429.SayHello")
+    @ResponseWrapper(localName = "sayHelloResponse", targetNamespace = "http://com.redhat.gss.example.soap/",
+            className = "org.jboss.test.ws.jaxws.cxf.jbws4429.SayHelloResponse")
+    String sayHello(
+            @WebParam(name = "arg0", targetNamespace = "")
+            String arg0);
+
+}

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/HelloService.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/HelloService.java
@@ -18,13 +18,13 @@
  */
 package org.jboss.test.ws.jaxws.cxf.jbws4429;
 
-import jakarta.jws.WebMethod;
-import jakarta.jws.WebParam;
-import jakarta.jws.WebResult;
-import jakarta.jws.WebService;
-import jakarta.xml.bind.annotation.XmlSeeAlso;
-import jakarta.xml.ws.RequestWrapper;
-import jakarta.xml.ws.ResponseWrapper;
+import javax.jws.WebMethod;
+import javax.jws.WebParam;
+import javax.jws.WebResult;
+import javax.jws.WebService;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.ws.RequestWrapper;
+import javax.xml.ws.ResponseWrapper;
 
 @WebService(name = "HelloServiceService", targetNamespace = "http://com.redhat.gss.example.soap/")
 @XmlSeeAlso({

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/HelloServiceImpl.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/HelloServiceImpl.java
@@ -18,10 +18,10 @@
  */
 package org.jboss.test.ws.jaxws.cxf.jbws4429;
 
-import jakarta.ejb.Stateless;
-import jakarta.jws.HandlerChain;
-import jakarta.jws.WebMethod;
-import jakarta.jws.WebService;
+import javax.ejb.Stateless;
+import javax.jws.HandlerChain;
+import javax.jws.WebMethod;
+import javax.jws.WebService;
 
 @Stateless
 //@WebService(targetNamespace ="http://com.redhat.gss.example.soap/") // correct targetNamespace

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/HelloServiceImpl.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/HelloServiceImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.test.ws.jaxws.cxf.jbws4429;
+
+import jakarta.ejb.Stateless;
+import jakarta.jws.HandlerChain;
+import jakarta.jws.WebMethod;
+import jakarta.jws.WebService;
+
+@Stateless
+//@WebService(targetNamespace ="http://com.redhat.gss.example.soap/") // correct targetNamespace
+@WebService(targetNamespace ="http://com.redhat.gss.invalid/")        // invalid targetNamespace that is not matched with wsdl distributed to clients
+@HandlerChain(file = "/handlers.xml")
+public class HelloServiceImpl {
+    @WebMethod
+    public String sayHello(String name) {
+        return "Hello, " + name;
+    }
+}

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/HelloServiceService.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/HelloServiceService.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.test.ws.jaxws.cxf.jbws4429;
+
+import java.net.URL;
+import javax.xml.namespace.QName;
+import jakarta.xml.ws.Service;
+import jakarta.xml.ws.WebEndpoint;
+import jakarta.xml.ws.WebServiceClient;
+import jakarta.xml.ws.WebServiceFeature;
+
+@WebServiceClient(name = "HelloServiceService", targetNamespace = "http://com.redhat.gss.example.soap/", wsdlLocation = "HelloServiceService.wsdl")
+public class HelloServiceService
+        extends Service
+{
+
+    private final static QName HELLOSERVICESERVICE_QNAME = new QName("http://com.redhat.gss.example.soap/", "HelloServiceService");
+
+    public HelloServiceService(URL wsdlLocation) {
+        super(wsdlLocation, HELLOSERVICESERVICE_QNAME);
+    }
+
+    /**
+     *
+     * @return
+     *     returns HelloService
+     */
+    @WebEndpoint(name = "HelloServicePort")
+    public HelloService getHelloServicePort() {
+        return super.getPort(new QName("http://com.redhat.gss.example.soap/", "HelloServicePort"), HelloService.class);
+    }
+
+    /**
+     *
+     * @param features
+     *     A list of {@link jakarta.xml.ws.WebServiceFeature} to configure on the proxy.  Supported features not in the <code>features</code> parameter will have their default values.
+     * @return
+     *     returns HelloService
+     */
+    @WebEndpoint(name = "HelloServicePort")
+    public HelloService getHelloServicePort(WebServiceFeature... features) {
+        return super.getPort(new QName("http://com.redhat.gss.example.soap/", "HelloServicePort"), HelloService.class, features);
+    }
+
+}
+

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/HelloServiceService.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/HelloServiceService.java
@@ -20,10 +20,10 @@ package org.jboss.test.ws.jaxws.cxf.jbws4429;
 
 import java.net.URL;
 import javax.xml.namespace.QName;
-import jakarta.xml.ws.Service;
-import jakarta.xml.ws.WebEndpoint;
-import jakarta.xml.ws.WebServiceClient;
-import jakarta.xml.ws.WebServiceFeature;
+import javax.xml.ws.Service;
+import javax.xml.ws.WebEndpoint;
+import javax.xml.ws.WebServiceClient;
+import javax.xml.ws.WebServiceFeature;
 
 @WebServiceClient(name = "HelloServiceService", targetNamespace = "http://com.redhat.gss.example.soap/", wsdlLocation = "HelloServiceService.wsdl")
 public class HelloServiceService
@@ -49,7 +49,7 @@ public class HelloServiceService
     /**
      *
      * @param features
-     *     A list of {@link jakarta.xml.ws.WebServiceFeature} to configure on the proxy.  Supported features not in the <code>features</code> parameter will have their default values.
+     *     A list of {@link javax.xml.ws.WebServiceFeature} to configure on the proxy.  Supported features not in the <code>features</code> parameter will have their default values.
      * @return
      *     returns HelloService
      */

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/JBWS4429TestCase.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/JBWS4429TestCase.java
@@ -20,7 +20,7 @@ package org.jboss.test.ws.jaxws.cxf.jbws4429;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.FileAsset;
@@ -28,14 +28,14 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.wsf.test.JBossWSTest;
 import org.jboss.wsf.test.JBossWSTestHelper;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.net.URL;
 
-@ExtendWith(ArquillianExtension.class)
+@RunWith(Arquillian.class)
 public class JBWS4429TestCase extends JBossWSTest {
     private static final String DEP = "jaxws-cxf-jbws4429";
 
@@ -61,9 +61,9 @@ public class JBWS4429TestCase extends JBossWSTest {
         HelloService service = clientService.getHelloServicePort();
         try {
             service.sayHello("Jim");
-            Assertions.fail("sayHello() call should fail");
+            Assert.fail("sayHello() call should fail");
         } catch (Exception e) {
-            Assertions.assertEquals("JBWS024118: BindingOperation is missing for authorization", e.getMessage());
+            Assert.assertEquals("JBWS024118: BindingOperation is missing for authorization", e.getMessage());
         }
 
     }

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/JBWS4429TestCase.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/JBWS4429TestCase.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.test.ws.jaxws.cxf.jbws4429;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.wsf.test.JBossWSTest;
+import org.jboss.wsf.test.JBossWSTestHelper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.File;
+import java.net.URL;
+
+@ExtendWith(ArquillianExtension.class)
+public class JBWS4429TestCase extends JBossWSTest {
+    private static final String DEP = "jaxws-cxf-jbws4429";
+
+    @ArquillianResource
+    private URL baseURL;
+
+    @Deployment(name = DEP, testable = false)
+    public static WebArchive createDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, DEP + ".war");
+        archive.setManifest(new StringAsset("Manifest-Version: 1.0\n"
+                        + "Dependencies: org.apache.cxf org.jboss.logging \n"))
+                .addClasses(HelloServiceImpl.class, LoggingHandler.class)
+                .add(new FileAsset(new File(JBossWSTestHelper.getTestResourcesDir() + "/jaxws/cxf/jbws4429/handlers.xml")), "WEB-INF/classes/handlers.xml")
+        ;
+        return archive;
+    }
+
+    @Test
+    @RunAsClient
+    public void testWS() throws Exception {
+        URL wsdlURL = JBWS4429TestCase.getResourceURL("/jaxws/cxf/jbws4429/WEB-INF/wsdl/HelloService.wsdl");
+        HelloServiceService clientService = new HelloServiceService(wsdlURL);
+        HelloService service = clientService.getHelloServicePort();
+        try {
+            service.sayHello("Jim");
+            Assertions.fail("sayHello() call should fail");
+        } catch (Exception e) {
+            Assertions.assertEquals("JBWS024118: BindingOperation is missing for authorization", e.getMessage());
+        }
+
+    }
+
+
+}

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/LoggingHandler.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/LoggingHandler.java
@@ -19,9 +19,9 @@
 package org.jboss.test.ws.jaxws.cxf.jbws4429;
 
 import javax.xml.namespace.QName;
-import jakarta.xml.ws.handler.MessageContext;
-import jakarta.xml.ws.handler.soap.SOAPHandler;
-import jakarta.xml.ws.handler.soap.SOAPMessageContext;
+import javax.xml.ws.handler.MessageContext;
+import javax.xml.ws.handler.soap.SOAPHandler;
+import javax.xml.ws.handler.soap.SOAPMessageContext;
 import java.util.Collections;
 import java.util.Set;
 

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/LoggingHandler.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/LoggingHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.test.ws.jaxws.cxf.jbws4429;
+
+import javax.xml.namespace.QName;
+import jakarta.xml.ws.handler.MessageContext;
+import jakarta.xml.ws.handler.soap.SOAPHandler;
+import jakarta.xml.ws.handler.soap.SOAPMessageContext;
+import java.util.Collections;
+import java.util.Set;
+
+public class LoggingHandler implements SOAPHandler<SOAPMessageContext> {
+
+    @Override
+    public boolean handleMessage(SOAPMessageContext soapMessageContext) {
+        boolean isOutBound = (boolean) soapMessageContext.get(SOAPMessageContext.MESSAGE_OUTBOUND_PROPERTY);
+        if (isOutBound) {
+            System.out.println("### outbound message from JBoss EAP ###");
+        } else {
+            System.out.println("### inbound message from a client ###");
+        }
+        return true;
+    }
+
+    @Override
+    public Set<QName> getHeaders() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public boolean handleFault(SOAPMessageContext soapMessageContext) {
+        return true;
+    }
+
+    @Override
+    public void close(MessageContext messageContext) {
+        // no-operation
+    }
+}

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/ObjectFactory.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/ObjectFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.test.ws.jaxws.cxf.jbws4429;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.annotation.XmlElementDecl;
+import jakarta.xml.bind.annotation.XmlRegistry;
+import javax.xml.namespace.QName;
+
+
+/**
+ * This object contains factory methods for each
+ * Java content interface and Java element interface
+ * generated in the com.redhat.gss.example.soap package.
+ * <p>An ObjectFactory allows you to programatically
+ * construct new instances of the Java representation
+ * for XML content. The Java representation of XML
+ * content can consist of schema derived interfaces
+ * and classes representing the binding of schema
+ * type definitions, element declarations and model
+ * groups.  Factory methods for each of these are
+ * provided in this class.
+ *
+ */
+@XmlRegistry
+public class ObjectFactory {
+
+    private final static QName _SayHelloResponse_QNAME = new QName("http://com.redhat.gss.example.soap/", "sayHelloResponse");
+    private final static QName _SayHello_QNAME = new QName("http://com.redhat.gss.example.soap/", "sayHello");
+
+    /**
+     * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: com.redhat.gss.example.soap
+     *
+     */
+    public ObjectFactory() {
+    }
+
+    /**
+     * Create an instance of {@link SayHello }
+     *
+     */
+    public SayHello createSayHello() {
+        return new SayHello();
+    }
+
+    /**
+     * Create an instance of {@link SayHelloResponse }
+     *
+     */
+    public SayHelloResponse createSayHelloResponse() {
+        return new SayHelloResponse();
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link SayHelloResponse }{@code >}}
+     *
+     */
+    @XmlElementDecl(namespace = "http://com.redhat.gss.example.soap/", name = "sayHelloResponse")
+    public JAXBElement<SayHelloResponse> createSayHelloResponse(SayHelloResponse value) {
+        return new JAXBElement<SayHelloResponse>(_SayHelloResponse_QNAME, SayHelloResponse.class, null, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link SayHello }{@code >}}
+     *
+     */
+    @XmlElementDecl(namespace = "http://com.redhat.gss.example.soap/", name = "sayHello")
+    public JAXBElement<SayHello> createSayHello(SayHello value) {
+        return new JAXBElement<SayHello>(_SayHello_QNAME, SayHello.class, null, value);
+    }
+
+}

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/ObjectFactory.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/ObjectFactory.java
@@ -17,9 +17,9 @@
  * under the License.
  */
 package org.jboss.test.ws.jaxws.cxf.jbws4429;
-import jakarta.xml.bind.JAXBElement;
-import jakarta.xml.bind.annotation.XmlElementDecl;
-import jakarta.xml.bind.annotation.XmlRegistry;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlElementDecl;
+import javax.xml.bind.annotation.XmlRegistry;
 import javax.xml.namespace.QName;
 
 

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/SayHello.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/SayHello.java
@@ -18,9 +18,9 @@
  */
 package org.jboss.test.ws.jaxws.cxf.jbws4429;
 
-import jakarta.xml.bind.annotation.XmlAccessType;
-import jakarta.xml.bind.annotation.XmlAccessorType;
-import jakarta.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
 
 
 /**

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/SayHello.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/SayHello.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.test.ws.jaxws.cxf.jbws4429;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+
+
+/**
+ * <p>Java class for sayHello complex type.
+ *
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ *
+ * <pre>
+ * &lt;complexType name="sayHello">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="arg0" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ *
+ *
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "sayHello", propOrder = {
+        "arg0"
+})
+public class SayHello {
+
+    protected String arg0;
+
+    /**
+     * Gets the value of the arg0 property.
+     *
+     * @return
+     *     possible object is
+     *     {@link String }
+     *
+     */
+    public String getArg0() {
+        return arg0;
+    }
+
+    /**
+     * Sets the value of the arg0 property.
+     *
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *
+     */
+    public void setArg0(String value) {
+        this.arg0 = value;
+    }
+
+}
+

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/SayHelloResponse.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/SayHelloResponse.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.test.ws.jaxws.cxf.jbws4429;
+
+import jakarta.xml.bind.annotation.*;
+
+
+/**
+ * <p>Java class for sayHelloResponse complex type.
+ *
+ * <p>The following schema fragment specifies the expected content contained within this class.
+ *
+ * <pre>
+ * &lt;complexType name="sayHelloResponse">
+ *   &lt;complexContent>
+ *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+ *       &lt;sequence>
+ *         &lt;element name="return" type="{http://www.w3.org/2001/XMLSchema}string" minOccurs="0"/>
+ *       &lt;/sequence>
+ *     &lt;/restriction>
+ *   &lt;/complexContent>
+ * &lt;/complexType>
+ * </pre>
+ *
+ *
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "sayHelloResponse", propOrder = {
+        "_return"
+})
+public class SayHelloResponse {
+
+    @XmlElement(name = "return")
+    protected String _return;
+
+    /**
+     * Gets the value of the return property.
+     *
+     * @return
+     *     possible object is
+     *     {@link String }
+     *
+     */
+    public String getReturn() {
+        return _return;
+    }
+
+    /**
+     * Sets the value of the return property.
+     *
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *
+     */
+    public void setReturn(String value) {
+        this._return = value;
+    }
+
+}
+

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/SayHelloResponse.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4429/SayHelloResponse.java
@@ -18,7 +18,7 @@
  */
 package org.jboss.test.ws.jaxws.cxf.jbws4429;
 
-import jakarta.xml.bind.annotation.*;
+import javax.xml.bind.annotation.*;
 
 
 /**

--- a/modules/testsuite/cxf-tests/src/test/resources/jaxws/cxf/jbws4429/WEB-INF/wsdl/HelloService.wsdl
+++ b/modules/testsuite/cxf-tests/src/test/resources/jaxws/cxf/jbws4429/WEB-INF/wsdl/HelloService.wsdl
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='UTF-8'?><wsdl:definitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://com.redhat.gss.example.soap/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:ns1="http://schemas.xmlsoap.org/soap/http" name="HelloServiceService" targetNamespace="http://com.redhat.gss.example.soap/">
+<wsdl:types>
+    <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://com.redhat.gss.example.soap/" elementFormDefault="unqualified" targetNamespace="http://com.redhat.gss.example.soap/" version="1.0">
+
+        <xs:element name="sayHello" type="tns:sayHello"/>
+
+        <xs:element name="sayHelloResponse" type="tns:sayHelloResponse"/>
+
+        <xs:complexType name="sayHello">
+            <xs:sequence>
+                <xs:element minOccurs="0" name="arg0" type="xs:string"/>
+            </xs:sequence>
+        </xs:complexType>
+
+        <xs:complexType name="sayHelloResponse">
+            <xs:sequence>
+                <xs:element minOccurs="0" name="return" type="xs:string"/>
+            </xs:sequence>
+        </xs:complexType>
+
+    </xs:schema>
+</wsdl:types>
+<wsdl:message name="sayHelloResponse">
+    <wsdl:part element="tns:sayHelloResponse" name="parameters">
+    </wsdl:part>
+</wsdl:message>
+<wsdl:message name="sayHello">
+    <wsdl:part element="tns:sayHello" name="parameters">
+    </wsdl:part>
+</wsdl:message>
+<wsdl:portType name="HelloService">
+    <wsdl:operation name="sayHello">
+        <wsdl:input message="tns:sayHello" name="sayHello">
+        </wsdl:input>
+        <wsdl:output message="tns:sayHelloResponse" name="sayHelloResponse">
+        </wsdl:output>
+    </wsdl:operation>
+</wsdl:portType>
+<wsdl:binding name="HelloServiceServiceSoapBinding" type="tns:HelloService">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="sayHello">
+        <soap:operation soapAction="" style="document"/>
+        <wsdl:input name="sayHello">
+            <soap:body use="literal"/>
+        </wsdl:input>
+        <wsdl:output name="sayHelloResponse">
+            <soap:body use="literal"/>
+        </wsdl:output>
+    </wsdl:operation>
+</wsdl:binding>
+<wsdl:service name="HelloServiceService">
+    <wsdl:port binding="tns:HelloServiceServiceSoapBinding" name="HelloServicePort">
+        <soap:address location="http://@jboss.bind.address@:@cxf-tests.jboss_8080@/jaxws-cxf-jbws4429/HelloServiceImpl"/>
+    </wsdl:port>
+</wsdl:service>
+</wsdl:definitions>

--- a/modules/testsuite/cxf-tests/src/test/resources/jaxws/cxf/jbws4429/WEB-INF/wsdl/HelloService.wsdl
+++ b/modules/testsuite/cxf-tests/src/test/resources/jaxws/cxf/jbws4429/WEB-INF/wsdl/HelloService.wsdl
@@ -50,7 +50,7 @@
 </wsdl:binding>
 <wsdl:service name="HelloServiceService">
     <wsdl:port binding="tns:HelloServiceServiceSoapBinding" name="HelloServicePort">
-        <soap:address location="http://@jboss.bind.address@:@cxf-tests.jboss_8080@/jaxws-cxf-jbws4429/HelloServiceImpl"/>
+        <soap:address location="http://@jboss.bind.address@:@add_int(port-offset.cxf-tests.jboss,8080)@/jaxws-cxf-jbws4429/HelloServiceImpl"/>
     </wsdl:port>
 </wsdl:service>
 </wsdl:definitions>

--- a/modules/testsuite/cxf-tests/src/test/resources/jaxws/cxf/jbws4429/handlers.xml
+++ b/modules/testsuite/cxf-tests/src/test/resources/jaxws/cxf/jbws4429/handlers.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<handler-chains xmlns="https://jakarta.ee/xml/ns/jakartaee">
+    <handler-chain>
+        <handler>
+            <handler-class>org.jboss.test.ws.jaxws.cxf.jbws4429.LoggingHandler</handler-class>
+        </handler>
+    </handler-chain>
+</handler-chains>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBWS-4429

This PR is based on https://github.com/jbossws/jbossws-cxf/pull/531 and adds a test case for it.

The upstream PR is #539 