### PR TITLE
[JBWS-4438] Authentication always failed when the webservice security is configured with a custom realm

### DIFF
--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/security/authentication/SubjectCreator.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/security/authentication/SubjectCreator.java
@@ -182,7 +182,11 @@ public class SubjectCreator
             }
             if (isDigest && created != null && nonce != null) { // username token profile is using digest
                // verify client's digest
-               TwoWayPassword recoveredTwoWayPassword = identity.getCredential(PasswordCredential.class).getPassword(TwoWayPassword.class);
+               PasswordCredential passwordCredential = identity.getCredential(PasswordCredential.class);
+               if (passwordCredential == null) {
+                  throw MESSAGES.authenticationFailed(principal.getName());
+               }
+               TwoWayPassword recoveredTwoWayPassword = passwordCredential.getPassword(TwoWayPassword.class);
                if (recoveredTwoWayPassword == null) {
                   SECURITY_LOGGER.plainTextPasswordMustBeRecoverable(principal.getName(), null);
                   throw MESSAGES.authenticationFailed(principal.getName());


### PR DESCRIPTION
Backporting https://github.com/jbossws/jbossws-cxf/pull/578 to 5.4.x

https://issues.redhat.com/browse/JBWS-4438