### PR TITLE
[JBWS-4444] Server throws IllegalStateException when call to SOAPHandler's getHeaders/handleFault/close methods is performed and their code include the CDI bean invocation

### DIFF
--- a/docbook/src/main/doc/adoc/content/chapter-5-Advanced_User_Guide.adoc
+++ b/docbook/src/main/doc/adoc/content/chapter-5-Advanced_User_Guide.adoc
@@ -1374,63 +1374,6 @@ A new instance of each specified interceptor class will be added to the
 client or endpoint the configuration is assigned to. The interceptor
 classes must have a no-argument constructor.
 
-When using CXF interceptors that access CDI beans in the WildFly environment, you need to ensure that
-the Thread Context ClassLoader (TCCL) is correctly set to make sure the CDI beans are loaded/read properly.
-
-To do this, CXF interceptors with CDI access should extend `org.jboss.wsf.stack.cxf.interceptor.AbstractTCCLPhaseInterceptor`
-and override the method `handleMessageWithTCCL(Message message)` to ensure the proper classloader is set before execution
-:
-
-```
-public class CDIOutInterceptor extends AbstractTCCLPhaseInterceptor<Message> {
-public CDIOutInterceptor() {
-super(Phase.PRE_STREAM);
-}
-
-   @Override
-   public void handleMessageWithTCCL(Message message) throws Fault {
-      if (!MessageUtils.isRequestor(message)) {
-         DelegateBean bean = new DelegateBean();
-      }
-   }
-}
-```
-
-```
-import jakarta.enterprise.context.Dependent;
-import jakarta.enterprise.inject.spi.CDI;
-
-@Dependent
-public class DelegateBean {
-    EmptyBean logic = CDI.current().select(EmptyBean.class).get();
-}
-```
-
-```
-@Dependent
-public class EmptyBean {
-}
-```
-The `AbstractTCCLPhaseInterceptor` can set the deployment classloader to thread context classloader before the
-handleMessage() method is called, and it restores the previous classloader afterward.
-
-Since AbstractTCCLPhaseInterceptor was introduced in version 7.3.0.Final and is included in
-'org.jboss.ws.cxf.jbossws-cxf-server' WildFly module dependency, you must add this necessary dependency to the MANIFEST.MF file of your deployment artifact.
-Additionally, don't forget to include the `org.apache.cxf` dependency for importing the cxf interceptor apis. Here is the package example code with Arquillian to
-add these two dependencies to the user's deployment artifact. Please use the same dependency adding format when
-including these dependencies to the MANIFEST.MF file:
-```
-    public static WebArchive createDeployment() {
-        WebArchive archive = ShrinkWrap.create(WebArchive.class, DEP + ".war");
-        archive.setManifest(new StringAsset("Manifest-Version: 1.0\n"
-                        + "Dependencies: org.apache.cxf,org.jboss.ws.cxf.jbossws-cxf-server\n"))
-                .addClasses(HelloBean.class, DelegateBean.class, EmptyBean.class, CDIOutInterceptor.class, LoggingHandler.class)
-                .addAsWebInfResource(new File(JBossWSTestHelper.getTestResourcesDir() + "/jaxws/cxf/jbws4430/WEB-INF/wsdl/HelloWorld.wsdl"), "wsdl/HelloWorld.wsdl")
-                .add(new FileAsset(new File(JBossWSTestHelper.getTestResourcesDir() + "/jaxws/cxf/jbws4430/handlers.xml")), "WEB-INF/classes/handlers.xml")
-                .setWebXML(new File(JBossWSTestHelper.getTestResourcesDir() + "/jaxws/cxf/jbws4430/WEB-INF/web.xml"));
-        return archive;
-    }
-```
 
 ==== Apache CXF features
 

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/configuration/ServerBeanCustomizer.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/configuration/ServerBeanCustomizer.java
@@ -21,18 +21,23 @@ package org.jboss.wsf.stack.cxf.configuration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.UnaryOperator;
 
+import jakarta.xml.ws.Binding;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
 import org.apache.cxf.annotations.UseAsyncMethod;
 import org.apache.cxf.frontend.ServerFactoryBean;
+import org.apache.cxf.interceptor.Interceptor;
 import org.apache.cxf.jaxws.support.JaxWsEndpointImpl;
 import org.apache.cxf.message.Message;
+import org.apache.cxf.service.Service;
 import org.apache.cxf.service.ServiceImpl;
 import org.apache.cxf.transport.http.DestinationRegistry;
 import org.apache.cxf.transport.http.HTTPTransportFactory;
-import org.apache.cxf.wsdl.service.factory.ReflectionServiceFactoryBean;
 import org.jboss.ws.api.util.ServiceLoader;
 import org.jboss.ws.common.configuration.BasicConfigResolver;
-import org.jboss.ws.common.deployment.DefaultHttpEndpoint;
 import org.jboss.wsf.spi.classloading.ClassLoaderProvider;
 import org.jboss.wsf.spi.deployment.AnnotationsInfo;
 import org.jboss.wsf.spi.deployment.ArchiveDeployment;
@@ -43,12 +48,14 @@ import org.jboss.wsf.stack.cxf.client.configuration.BeanCustomizer;
 import org.jboss.wsf.stack.cxf.deployment.EndpointImpl;
 import org.jboss.wsf.stack.cxf.deployment.WSDLFilePublisher;
 import org.jboss.wsf.stack.cxf.i18n.Loggers;
+import org.jboss.wsf.stack.cxf.interceptor.TCCLAwareInterceptorReplacer;
 import org.jboss.wsf.stack.cxf.security.authentication.SubjectCreatingPolicyInterceptor;
 import org.jboss.wsf.stack.cxf.transport.JBossWSDestinationRegistryImpl;
 
 /**
  *
  * @author alessio.soldano@jboss.com
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  * @since 16-Jun-2010
  */
 public class ServerBeanCustomizer extends BeanCustomizer
@@ -64,6 +71,41 @@ public class ServerBeanCustomizer extends BeanCustomizer
       {
          configureEndpoint((EndpointImpl) beanInstance);
       }
+
+      if (beanInstance instanceof JaxWsEndpointImpl)
+      {
+         final JaxWsEndpointImpl jaxwsEndpoint = (JaxWsEndpointImpl)beanInstance;
+         final Binding jaxwsBinding = jaxwsEndpoint.getJaxwsBinding();
+         final UnaryOperator<Interceptor<? extends Message>> interceptorReplacer = new TCCLAwareInterceptorReplacer(jaxwsBinding);
+
+         // Endpoint interceptors
+         jaxwsEndpoint.getInInterceptors().replaceAll(interceptorReplacer);
+         jaxwsEndpoint.getOutInterceptors().replaceAll(interceptorReplacer);
+         jaxwsEndpoint.getInFaultInterceptors().replaceAll(interceptorReplacer);
+         jaxwsEndpoint.getOutFaultInterceptors().replaceAll(interceptorReplacer);
+
+         // Service interceptors
+         final Service service = jaxwsEndpoint.getService();
+         service.getInInterceptors().replaceAll(interceptorReplacer);
+         service.getOutInterceptors().replaceAll(interceptorReplacer);
+         service.getInFaultInterceptors().replaceAll(interceptorReplacer);
+         service.getOutFaultInterceptors().replaceAll(interceptorReplacer);
+
+         // Bus interceptors
+         final Bus bus = BusFactory.getThreadDefaultBus(false);
+         bus.getInInterceptors().replaceAll(interceptorReplacer);
+         bus.getOutInterceptors().replaceAll(interceptorReplacer);
+         bus.getInFaultInterceptors().replaceAll(interceptorReplacer);
+         bus.getOutFaultInterceptors().replaceAll(interceptorReplacer);
+
+         // Binding interceptors
+         final org.apache.cxf.binding.Binding binding = jaxwsEndpoint.getBinding();
+         binding.getInInterceptors().replaceAll(interceptorReplacer);
+         binding.getOutInterceptors().replaceAll(interceptorReplacer);
+         binding.getInFaultInterceptors().replaceAll(interceptorReplacer);
+         binding.getOutFaultInterceptors().replaceAll(interceptorReplacer);
+      }
+
       if (beanInstance instanceof ServerFactoryBean)
       {
          ServerFactoryBean factory = (ServerFactoryBean) beanInstance;

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/AbstractTCCLAwarePhaseInterceptor.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/AbstractTCCLAwarePhaseInterceptor.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.wsf.stack.cxf.interceptor;
+
+import java.util.Collection;
+
+import org.apache.cxf.interceptor.Fault;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.AbstractPhaseInterceptor;
+import org.apache.cxf.phase.PhaseInterceptor;
+import org.jboss.wsf.stack.cxf.JAXPDelegateClassLoader;
+
+/**
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+abstract class AbstractTCCLAwarePhaseInterceptor<M extends Message> extends AbstractPhaseInterceptor<M> {
+
+    final PhaseInterceptor<M> delegate;
+
+    AbstractTCCLAwarePhaseInterceptor(final PhaseInterceptor<M> delegate) {
+        super(delegate.getId(), delegate.getPhase());
+        this.delegate = delegate;
+        this.addBefore(delegate.getBefore());
+        this.addAfter(delegate.getAfter());
+    }
+
+    // TCCL aware methods
+
+    @Override
+    public void handleFault(final M message) {
+        final ClassLoader original = SecurityActions.getContextClassLoader();
+        try {
+            if (original instanceof JAXPDelegateClassLoader) {
+                JAXPDelegateClassLoader jaxpLoader = (JAXPDelegateClassLoader) original;
+                SecurityActions.setContextClassLoader(jaxpLoader.getDelegate());
+            }
+            delegate.handleFault(message);
+        } finally {
+            SecurityActions.setContextClassLoader(original);
+        }
+    }
+
+    @Override
+    public void handleMessage(M message) throws Fault {
+        final ClassLoader original = SecurityActions.getContextClassLoader();
+        try {
+            if (original instanceof JAXPDelegateClassLoader) {
+                JAXPDelegateClassLoader jaxpLoader = (JAXPDelegateClassLoader) original;
+                SecurityActions.setContextClassLoader(jaxpLoader.getDelegate());
+            }
+            delegate.handleMessage(message);
+        } finally {
+            SecurityActions.setContextClassLoader(original);
+        }
+    }
+
+    // TCCL unaware methods
+
+    @Override
+    public Collection<PhaseInterceptor<? extends Message>> getAdditionalInterceptors() {
+        return delegate.getAdditionalInterceptors();
+    }
+
+    // SoapInterceptor implementation methods - optional for this wrapper
+
+    @Override
+    public String toString() {
+        return getClass().getName() + " --- delegating to ---> " + delegate.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return delegate.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) return true;
+        if (!(obj instanceof AbstractTCCLAwarePhaseInterceptor)) return false;
+        return delegate.equals(((AbstractTCCLAwarePhaseInterceptor) obj).delegate);
+    }
+}

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/AbstractTCCLPhaseInterceptor.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/AbstractTCCLPhaseInterceptor.java
@@ -23,6 +23,7 @@ import org.apache.cxf.interceptor.Fault;
 import org.apache.cxf.message.Message;
 import org.apache.cxf.phase.AbstractPhaseInterceptor;
 
+@Deprecated
 public abstract class AbstractTCCLPhaseInterceptor<T extends Message> extends AbstractPhaseInterceptor<T> {
     public AbstractTCCLPhaseInterceptor(String phase) {
         super(null, phase, false);

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/HandlerConfigInterceptor.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/HandlerConfigInterceptor.java
@@ -196,6 +196,20 @@ public class HandlerConfigInterceptor extends AbstractPhaseInterceptor<Message>
          }
       }
 
+      public void mepComplete(Message message) {
+         ClassLoader original = SecurityActions.getContextClassLoader();
+         try {
+            if (original instanceof JAXPDelegateClassLoader) {
+               JAXPDelegateClassLoader jaxpLoader = (JAXPDelegateClassLoader)original;
+               SecurityActions.setContextClassLoader(jaxpLoader.getDelegate());
+            }
+            super.mepComplete(message);
+         } finally {
+            SecurityActions.setContextClassLoader(original);
+         }
+      }
+
+
       protected void checkAuthorization(MessageContext ctx)
       {
          if ((Boolean) ctx.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY))

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/TCCLAwareInterceptorReplacer.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/TCCLAwareInterceptorReplacer.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.wsf.stack.cxf.interceptor;
+
+import java.util.function.UnaryOperator;
+
+import jakarta.xml.ws.Binding;
+
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.binding.soap.interceptor.SoapInterceptor;
+import org.apache.cxf.interceptor.Interceptor;
+import org.apache.cxf.jaxws.handler.soap.SOAPHandlerInterceptor;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.phase.PhaseInterceptor;
+
+/**
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+public final class TCCLAwareInterceptorReplacer implements UnaryOperator<Interceptor<? extends Message>> {
+
+    private final Binding binding;
+
+    public TCCLAwareInterceptorReplacer(final Binding binding) {
+        this.binding = binding;
+    }
+
+    @Override
+    public Interceptor<? extends Message> apply(final Interceptor<? extends Message> interceptor) {
+        return shouldReplaceInterceptor(interceptor) ? replace((PhaseInterceptor<? extends Message>)interceptor) : interceptor;
+    }
+
+    @SuppressWarnings("unchecked")
+    private PhaseInterceptor<? extends Message> replace(final PhaseInterceptor<? extends Message> interceptor) {
+        if (interceptor instanceof AbstractTCCLAwarePhaseInterceptor) {
+            return interceptor; // nothing to replace - TCCL aware interceptor is already in place
+        }
+        if (interceptor instanceof SoapInterceptor) {
+            return new TCCLAwareSoapPhaseInterceptor(binding, (PhaseInterceptor<SoapMessage>) interceptor);
+        } else {
+            return new TCCLAwarePhaseInterceptor((PhaseInterceptor<Message>) interceptor);
+        }
+    }
+
+    private static boolean shouldReplaceInterceptor(final Interceptor<? extends Message> interceptor) {
+        final boolean isApacheCXFSOAPHandlerInterceptor = interceptor instanceof SOAPHandlerInterceptor;
+        final boolean isNotApacheCXFInterceptor = !interceptor.getClass().getName().startsWith("org.apache.cxf");
+        return isApacheCXFSOAPHandlerInterceptor || isNotApacheCXFInterceptor;
+    }
+
+}

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/TCCLAwarePhaseInterceptor.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/TCCLAwarePhaseInterceptor.java
@@ -16,22 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.jboss.test.ws.jaxws.cxf.jbws4430;
-import org.apache.cxf.interceptor.Fault;
+package org.jboss.wsf.stack.cxf.interceptor;
+
 import org.apache.cxf.message.Message;
-import org.apache.cxf.message.MessageUtils;
-import org.apache.cxf.phase.AbstractPhaseInterceptor;
-import org.apache.cxf.phase.Phase;
+import org.apache.cxf.phase.PhaseInterceptor;
 
-public class CDIOutInterceptor extends AbstractPhaseInterceptor<Message> {
-   public CDIOutInterceptor() {
-      super(Phase.PRE_STREAM);
-   }
-
-   @Override
-   public void handleMessage(Message message) throws Fault {
-      if (!MessageUtils.isRequestor(message)) {
-         DelegateBean bean = new DelegateBean();
-      }
-   }
+/**
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+final class TCCLAwarePhaseInterceptor extends AbstractTCCLAwarePhaseInterceptor<Message> {
+    TCCLAwarePhaseInterceptor(final PhaseInterceptor<Message> delegate) {
+        super(delegate);
+    }
 }

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/TCCLAwareSoapPhaseInterceptor.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/interceptor/TCCLAwareSoapPhaseInterceptor.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.wsf.stack.cxf.interceptor;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.xml.namespace.QName;
+
+import jakarta.xml.ws.Binding;
+import jakarta.xml.ws.handler.Handler;
+import jakarta.xml.ws.handler.soap.SOAPHandler;
+
+import org.apache.cxf.binding.soap.SoapMessage;
+import org.apache.cxf.binding.soap.interceptor.SoapInterceptor;
+import org.apache.cxf.helpers.CastUtils;
+import org.apache.cxf.phase.PhaseInterceptor;
+import org.jboss.wsf.stack.cxf.JAXPDelegateClassLoader;
+
+/**
+ * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
+ */
+final class TCCLAwareSoapPhaseInterceptor extends AbstractTCCLAwarePhaseInterceptor<SoapMessage> implements SoapInterceptor {
+
+    private final Binding binding;
+
+    TCCLAwareSoapPhaseInterceptor(final Binding binding, final PhaseInterceptor<SoapMessage> delegate) {
+        super(delegate);
+        this.binding = binding;
+    }
+
+    // TCCL aware methods
+
+    @Override
+    public Set<QName> getUnderstoodHeaders() {
+        final Set<QName> understood = new HashSet<>();
+        for (Handler<?> h : binding.getHandlerChain()) {
+            if (h instanceof SOAPHandler) {
+                final ClassLoader original = SecurityActions.getContextClassLoader();
+                try {
+                    if (original instanceof JAXPDelegateClassLoader) {
+                        JAXPDelegateClassLoader jaxpLoader = (JAXPDelegateClassLoader)original;
+                        SecurityActions.setContextClassLoader(jaxpLoader.getDelegate());
+                    }
+                    final Set<QName> headers = CastUtils.cast(((SOAPHandler<?>) h).getHeaders());
+                    if (headers != null) {
+                        understood.addAll(headers);
+                    }
+                } finally {
+                    SecurityActions.setContextClassLoader(original);
+                }
+            }
+        }
+        return understood;
+    }
+
+    // TCCL unaware methods
+
+    public Set<URI> getRoles() {
+        return ((SoapInterceptor) delegate).getRoles();
+    }
+
+}

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4430/HelloBean.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4430/HelloBean.java
@@ -31,6 +31,9 @@ public class HelloBean {
 
     @jakarta.jws.WebMethod
     public String hello(String name) {
+        if (name.isEmpty()) {
+            throw new IllegalArgumentException("Empty name");
+        }
         return "Hello " + name;
     }
 }

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4430/JBWS4430TestCase.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4430/JBWS4430TestCase.java
@@ -22,6 +22,8 @@ import jakarta.xml.ws.Service;
 import java.io.File;
 import java.net.URL;
 import javax.xml.namespace.QName;
+
+import jakarta.xml.ws.soap.SOAPFaultException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit5.ArquillianExtension;
@@ -66,6 +68,12 @@ public class JBWS4430TestCase extends JBossWSTest {
         Service service = Service.create(wsdlURL, serviceName);
         Hello proxy = (Hello) service.getPort(portName, Hello.class);
         Assertions.assertEquals("Hello jbossws", proxy.hello("jbossws"));
+        try {
+            proxy.hello("");
+            fail("An exception is expected to test the LoggingHandler.handleFault()");
+        } catch(Exception e) {
+            Assertions.assertInstanceOf(SOAPFaultException.class, e, "unexpected exception");
+        }
 
     }
 

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4430/LoggingHandler.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws4430/LoggingHandler.java
@@ -37,16 +37,18 @@ public class LoggingHandler implements SOAPHandler<SOAPMessageContext> {
 
     @Override
     public Set<QName> getHeaders() {
+        new DelegateBean();
         return Collections.emptySet();
     }
 
     @Override
     public boolean handleFault(SOAPMessageContext soapMessageContext) {
+        new DelegateBean();
         return true;
     }
 
     @Override
     public void close(MessageContext messageContext) {
-        // no-operation
+        new DelegateBean();
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/JBWS-4444