### PR TITLE
[JBWS-4478] - Set the wildfly1100.version property to 11.0.0.Final to fix build errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <wildfly902.version>9.0.2.Final</wildfly902.version>
     <wildfly1000.version>10.0.0.Final</wildfly1000.version>
     <wildfly1010.version>10.1.0.Final</wildfly1010.version>
-    <wildfly1100.version>11.0.0.CR1-SNAPSHOT</wildfly1100.version>
+    <wildfly1100.version>11.0.0.Final</wildfly1100.version>
     <ejb.api.version>1.0.2.Final</ejb.api.version>
     <cxf.version>3.1.13</cxf.version>
     <cxf.asm.version>3.3.1</cxf.asm.version>


### PR DESCRIPTION
SSIA, see https://issues.redhat.com/browse/JBWS-4478