### PR TITLE
[JBWS-4477] - Resolving intermittent CI checks failures due to the asciidoc Maven plugin PDF generation timeout

### DIFF
--- a/.github/workflows/apache-cxf-build.yml
+++ b/.github/workflows/apache-cxf-build.yml
@@ -46,7 +46,7 @@ jobs:
         id: get-cxf-version
         shell: bash
         run: |
-          CXF_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          CXF_VERSION=$(mvn -B help:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "version=$CXF_VERSION" >> $GITHUB_OUTPUT
           echo "Apache CXF snapshot version: $CXF_VERSION"
         working-directory: apache-cxf

--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v5
       - name: Build with Maven Java ${{ matrix.java }} ${{ matrix.profile }}
         run: |
-          mvn -s ./.m2-settings.xml -fae ${{ matrix.profile }} clean install
+          mvn -B -s ./.m2-settings.xml -fae ${{ matrix.profile }} clean install
       - uses: actions/upload-artifact@v6
         if: failure()
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,7 +39,7 @@ jobs:
           MAVEN_OPTS: "-Xmx2048m -Xms1024m -XX:MaxMetaspaceSize=512m -XX:+UseStringDeduplication"
       - name: Build with Maven Java ${{ matrix.jdk-version }} ${{ matrix.profile }}
         run: |
-          mvn -s ./.m2-settings.xml -fae ${{ matrix.profile }} clean install
+          mvn -B -s ./.m2-settings.xml -fae ${{ matrix.profile }} clean install
       - uses: actions/upload-artifact@v6
         if: failure()
         with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,6 +34,8 @@ jobs:
           distribution: ${{ matrix.jdk-distribution }}
           java-version: ${{ matrix.jdk-version }}
       - name: Build docbook
+        # Skip on Windows + OpenJ9 17 due to known JRuby hang issue (JBWS-4477)
+        if: ${{ !(matrix.os == 'windows-latest' && matrix.jdk-distribution == 'adopt-openj9' && matrix.jdk-version == 17) }}
         run: mvn -B -s ./.m2-settings.xml -f docbook/pom.xml install
         env:
           MAVEN_OPTS: "-Xmx2048m -Xms1024m -XX:MaxMetaspaceSize=512m -XX:+UseStringDeduplication"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,9 @@ jobs:
           distribution: ${{ matrix.jdk-distribution }}
           java-version: ${{ matrix.jdk-version }}
       - name: Build docbook
-        run: mvn -s ./.m2-settings.xml -f docbook/pom.xml install
+        run: mvn -B -s ./.m2-settings.xml -f docbook/pom.xml install
+        env:
+          MAVEN_OPTS: "-Xmx2048m -Xms1024m -XX:MaxMetaspaceSize=512m -XX:+UseStringDeduplication ${{ (matrix.os == 'windows-latest' && matrix.jdk-distribution == 'adopt-openj9') && '-Djruby.compile.mode=OFF -Djruby.jit.threshold=-1' || '' }}"
       - name: Build with Maven Java ${{ matrix.jdk-version }} ${{ matrix.profile }}
         run: |
           mvn -s ./.m2-settings.xml -fae ${{ matrix.profile }} clean install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build docbook
         run: mvn -B -s ./.m2-settings.xml -f docbook/pom.xml install
         env:
-          MAVEN_OPTS: "-Xmx2048m -Xms1024m -XX:MaxMetaspaceSize=512m -XX:+UseStringDeduplication ${{ (matrix.os == 'windows-latest' && matrix.jdk-distribution == 'adopt-openj9') && '-Djruby.compile.mode=OFF -Djruby.jit.threshold=-1' || '' }}"
+          MAVEN_OPTS: "-Xmx2048m -Xms1024m -XX:MaxMetaspaceSize=512m -XX:+UseStringDeduplication"
       - name: Build with Maven Java ${{ matrix.jdk-version }} ${{ matrix.profile }}
         run: |
           mvn -s ./.m2-settings.xml -fae ${{ matrix.profile }} clean install

--- a/docbook/pom.xml
+++ b/docbook/pom.xml
@@ -26,7 +26,7 @@
          </dependencies>
          <configuration>
              <attributes>
-                 <source-highlighter>coderay</source-highlighter>
+                 <source-highlighter>rouge</source-highlighter>
                  <jbossws-version>${project.version}</jbossws-version>
                  <imagesdir>./image</imagesdir>
              </attributes>

--- a/docbook/pom.xml
+++ b/docbook/pom.xml
@@ -23,15 +23,19 @@
             <artifactId>asciidoctorj-pdf</artifactId>
             <version>2.3.19</version>
           </dependency>
-         </dependencies>
+        </dependencies>
          <configuration>
              <attributes>
-                 <source-highlighter>coderay</source-highlighter>
+                 <source-highlighter>rouge</source-highlighter>
                  <jbossws-version>${project.version}</jbossws-version>
                  <imagesdir>./image</imagesdir>
              </attributes>
              <sourceDirectory>src/main/doc/adoc</sourceDirectory>
              <sourceDocumentName>JBossWS-CXF.adoc</sourceDocumentName>
+             <enableVerbose>true</enableVerbose>
+             <logHandler>
+                 <outputToConsole>true</outputToConsole>
+             </logHandler>
           </configuration>
           <executions>
               <execution>

--- a/docbook/pom.xml
+++ b/docbook/pom.xml
@@ -25,6 +25,7 @@
           </dependency>
         </dependencies>
          <configuration>
+             <fork>true</fork>
              <attributes>
                  <source-highlighter>coderay</source-highlighter>
                  <jbossws-version>${project.version}</jbossws-version>

--- a/docbook/pom.xml
+++ b/docbook/pom.xml
@@ -21,12 +21,12 @@
           <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-pdf</artifactId>
-            <version>2.3.19</version>
+            <version>2.3.23</version>
           </dependency>
         </dependencies>
          <configuration>
              <attributes>
-                 <source-highlighter>rouge</source-highlighter>
+                 <source-highlighter>coderay</source-highlighter>
                  <jbossws-version>${project.version}</jbossws-version>
                  <imagesdir>./image</imagesdir>
              </attributes>

--- a/docbook/src/main/doc/adoc/JBossWS-CXF.adoc
+++ b/docbook/src/main/doc/adoc/JBossWS-CXF.adoc
@@ -3,7 +3,6 @@
 :toc:
 :toclevels: 3
 :doctype: book
-:title-logo-image:
 :leveloffset: -1
 
 include::content/Preface.adoc[]


### PR DESCRIPTION
Resolving intermittent CI checks failures due to the asciidoc Maven plugin PDF generation execution.

See https://redhat.atlassian.net/browse/JBWS-4477