### PR TITLE
[JBWS-4492] - CI: skipping docbook generation for OpenJ9 + Windows combination

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ jobs:
           java-version: ${{ matrix.jdk-version }}
       - name: Build docbook
         # Skip on Windows + OpenJ9 17 due to known JRuby hang issue (JBWS-4477)
-        if: ${{ !(matrix.os == 'windows-latest' && matrix.jdk-distribution == 'adopt-openj9' && matrix.jdk-version == 17) }}
+        if: ${{ !(matrix.os == 'windows-latest' && matrix.jdk-distribution == 'adopt-openj9') }}
         run: mvn -B -s ./.m2-settings.xml -f docbook/pom.xml install
         env:
           MAVEN_OPTS: "-Xmx2048m -Xms1024m -XX:MaxMetaspaceSize=512m -XX:+UseStringDeduplication"


### PR DESCRIPTION
SSIA, see https://redhat.atlassian.net/browse/JBWS-4492