### PR TITLE
[JBWS-4503] - Align jakarta.* and jboss.* dependencies version to WildFly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <jakarta.activation.api.version>2.1.4</jakarta.activation.api.version>
     <jakarta.angus.activation.version>2.0.3</jakarta.angus.activation.version>
     <jakarta.angus.mail.version>2.0.4</jakarta.angus.mail.version>
-    <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
+    <jakarta.annotation.api.version>3.0.0</jakarta.annotation.api.version>
     <jakarta.ejb.api.version>4.0.1</jakarta.ejb.api.version>
     <jakarta.enterprise.cdi.api.version>4.1.0</jakarta.enterprise.cdi.api.version>
     <jakarta.inject.api.version>2.0.1</jakarta.inject.api.version>
@@ -91,7 +91,7 @@
     <jakarta.jms.api.version>3.1.0</jakarta.jms.api.version>              <!-- See https://github.com/apache/cxf/blob/cxf-4.1.5/parent/pom.xml#L145 -->
     <jakarta.json.api.version>2.1.3</jakarta.json.api.version>
     <jakarta.mail.version>2.1.5</jakarta.mail.version>
-    <jakarta.servlet.api.version>6.0.0</jakarta.servlet.api.version>
+    <jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>
     <jakarta.xml.bind.api.version>4.0.4</jakarta.xml.bind.api.version>    <!-- See https://github.com/apache/cxf/blob/cxf-4.1.5/parent/pom.xml#L155 -->
     <jakarta.xml.soap.api.version>3.0.2</jakarta.xml.soap.api.version>    <!-- See https://github.com/apache/cxf/blob/cxf-4.1.5/parent/pom.xml#L143 -->
     <jakarta.xml.ws.api.version>4.0.3</jakarta.xml.ws.api.version>        <!-- See https://github.com/apache/cxf/blob/cxf-4.1.5/parent/pom.xml#L144 -->

--- a/pom.xml
+++ b/pom.xml
@@ -99,14 +99,14 @@
     <jboss.ejb.client.version>5.0.8.Final</jboss.ejb.client.version>
     <jboss.ejb3.ext.api.version>2.4.0.Final</jboss.ejb3.ext.api.version>
     <jboss.jaxbintros.version>2.0.1</jboss.jaxbintros.version>
-    <jboss.logging.version>3.6.1.Final</jboss.logging.version>
+    <jboss.logging.version>3.6.3.Final</jboss.logging.version>
     <jboss.logging.annotations.version>3.0.4.Final</jboss.logging.annotations.version>
     <jboss.logging.processor.version>3.0.4.Final</jboss.logging.processor.version>
     <jboss.logging.slf4j.version>1.2.1.Final</jboss.logging.slf4j.version>
-    <jboss.marshalling.version>2.2.3.Final</jboss.marshalling.version>
-    <jboss.marshalling.river.version>2.2.3.Final</jboss.marshalling.river.version>
+    <jboss.marshalling.version>2.3.0</jboss.marshalling.version>
+    <jboss.marshalling.river.version>2.3.0</jboss.marshalling.river.version>
     <jboss.modules.version>2.1.6.Final</jboss.modules.version>
-    <jboss.openjdk.orb.version>10.1.1.Final</jboss.openjdk.orb.version>
+    <jboss.openjdk.orb.version>10.1.3.Final</jboss.openjdk.orb.version>
     <jboss.remoting.version>5.0.31.Final</jboss.remoting.version>
     <jboss.remoting.jmx.version>3.1.0.Final</jboss.remoting.jmx.version>
     <jbossws.api.version>3.0.0.Final</jbossws.api.version>


### PR DESCRIPTION
- Issue: https://redhat.atlassian.net/browse/JBWS-4503

The changes are part of the plan to release jbossws-cxf-7.4.0.Final.

Note that the feature pack is still built against a WildFly version that supports JDK 11, i.e. 34.0.1.Final. This is expected for 7.4.x releases and will change with 8.x, see https://redhat.atlassian.net/browse/JBWS-4469