### PR TITLE
[JBWS-4512] - Upgrade wildfly dependencies to align with latest WildFly and for jbossws-cxf-7.4.0 consolidation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,15 +124,15 @@
     <shrinkwrap.version>1.2.6</shrinkwrap.version>
     <testcontainer.version>1.21.0</testcontainer.version>
     <velocity.version>2.4.1</velocity.version>
-    <wildfly.version>36.0.1.Final</wildfly.version>
-    <wildfly.client.properties.version>36.0.1.Final</wildfly.client.properties.version>
-    <wildfly.cloud.galleon.pack.version>8.0.0.Final</wildfly.cloud.galleon.pack.version>
-    <wildfly.controller.client.version>28.0.1.Final</wildfly.controller.client.version>
-    <wildfly.elytron.version>2.6.4.Final</wildfly.elytron.version>
-    <wildfly.galleon.plugin.version>7.3.1.Final</wildfly.galleon.plugin.version>
+    <wildfly.version>40.0.0.Final</wildfly.version>
+    <wildfly.client.properties.version>40.0.0.Final</wildfly.client.properties.version>
+    <wildfly.cloud.galleon.pack.version>9.2.3.Final</wildfly.cloud.galleon.pack.version>
+    <wildfly.controller.client.version>32.0.0.Final</wildfly.controller.client.version>
+    <wildfly.elytron.version>2.9.0.Final</wildfly.elytron.version>
+    <wildfly.galleon.plugin.version>8.1.5.Final</wildfly.galleon.plugin.version>
     <wildfly.naming.client.version>2.0.1.Final</wildfly.naming.client.version>
-    <wildfly.plugin.version>5.1.5.Final</wildfly.plugin.version>
-    <wildfly.security.webservices.client.version>3.1.4.Final</wildfly.security.webservices.client.version>
+    <wildfly.plugin.version>6.0.0.Final</wildfly.plugin.version>
+    <wildfly.security.webservices.client.version>4.0.0.Final</wildfly.security.webservices.client.version>
     <!--
       We should use 4.0.1 to be aligned with Apache CXF 4.1.5, see
       https://github.com/apache/cxf/blob/cxf-4.1.5/parent/pom.xml#L239


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/JBWS-4511

The feature pack is still built against WIldFly Galleon Feature Pack 34.0.1.Final, i.e. the last supporting JDK 11.
This is expected for jbossws-cxf-7.4.0 release.

Moving to a SE 17 based WildFly Galleon Feature Pack is planned for the next jbossws-cxf  major.  