### PR TITLE
Upgrade Apache CXF from 4.1.6 to 4.1.8

### DIFF
--- a/.github/workflows/apache-cxf-build.yml
+++ b/.github/workflows/apache-cxf-build.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     # Run every Monday at 00:00 UTC
     - cron: '0 0 * * 1'
+  workflow_dispatch:
+    inputs:
+      cxf-ref:
+        description: 'Apache CXF branch or tag to build (e.g. 4.1.x-fixes, cxf-4.1.8)'
+        required: false
+        default: '4.1.x-fixes'
 
 jobs:
   build:
@@ -22,7 +28,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: apache/cxf
-          ref: 4.1.x-fixes
+          ref: ${{ github.event.inputs.cxf-ref || '4.1.x-fixes' }}
           path: apache-cxf
 
       - uses: actions/cache@v6

--- a/docbook/src/main/doc/adoc/content/chapter-5-Advanced_User_Guide.adoc
+++ b/docbook/src/main/doc/adoc/content/chapter-5-Advanced_User_Guide.adoc
@@ -1714,6 +1714,51 @@ proxy.sayHello("World");
 ....
 
 
+==== Decoupled WS-Addressing Endpoints
+
+Starting with Apache CXF 4.1.8, decoupled WS-Addressing destination endpoints are blocked by default as part of CXF's SSRF hardening. JBossWS-CXF re-enables this feature automatically for backward compatibility, so existing WS-Addressing deployments that rely on decoupled endpoints (e.g. for asynchronous responses or decoupled fault-to destinations) continue to work without changes.
+
+The behavior is controlled through two system properties, evaluated in the following order of precedence:
+
+[cols="1,3,1",options="header"]
+|===
+|System property |Description |Default
+
+|`org.apache.cxf.ws.addressing.decoupled.enabled`
+|Native Apache CXF property. When set explicitly (e.g. via JVM `-D` flag or WildFly `<system-properties>`), it takes the highest precedence and is used as-is.
+|_(not set)_
+
+|`org.jboss.ws.cxf.decoupledEndpointEnabled`
+|JBossWS-CXF property. Consulted only when the native CXF property above is not set. Set it to `false` to opt out of the backward-compatible default.
+|`true`
+|===
+
+When neither property is set explicitly, JBossWS-CXF defaults to `true`, preserving the pre-CXF-4.1.8 behavior where decoupled WS-Addressing endpoints are allowed.
+
+===== Opting out
+
+To disable decoupled WS-Addressing endpoints and align with the CXF 4.1.8+ default, set the JBossWS-CXF property to `false`. In a WildFly server configuration:
+
+[source,xml]
+----
+<system-properties>
+    <property name="org.jboss.ws.cxf.decoupledEndpointEnabled" value="false"/>
+</system-properties>
+----
+
+Or via JVM argument:
+
+----
+-Dorg.jboss.ws.cxf.decoupledEndpointEnabled=false
+----
+
+Alternatively, the native CXF property can be used directly:
+
+----
+-Dorg.apache.cxf.ws.addressing.decoupled.enabled=false
+----
+
+
 === WS-Security
 
 

--- a/modules/client/src/main/java/org/jboss/wsf/stack/cxf/client/Constants.java
+++ b/modules/client/src/main/java/org/jboss/wsf/stack/cxf/client/Constants.java
@@ -62,6 +62,7 @@ public class Constants
    public static final String JBWS_CXF_DISABLE_SCHEMA_CACHE = "org.jboss.ws.cxf.disableSchemaCache";
    public static final String JBWS_CXF_DECODE_URL_PATH = "org.jboss.ws.cxf.decodeUrlPath";
    public static final String JBWS_CXF_URL_CHARSET = "org.jboss.ws.cxf.urlCharset";
+   public static final String JBWS_CXF_DECOUPLED_ENDPOINT_ENABLED = "org.jboss.ws.cxf.decoupledEndpointEnabled";
    //The flag to force use the URLConnectionHTTPConduit instead of the HttpClientHTTPConduit since CXF 4.0.4
    public static final String FORCE_URL_CONNECTION_CONDUIT = "force.urlconnection.http.conduit";
 }

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/config/CXFStackConfigFactory.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/config/CXFStackConfigFactory.java
@@ -29,6 +29,7 @@ import org.jboss.wsf.spi.classloading.ClassLoaderProvider;
 import org.jboss.wsf.spi.management.StackConfig;
 import org.jboss.wsf.spi.management.StackConfigFactory;
 import org.jboss.wsf.stack.cxf.addressRewrite.SoapAddressRewriteHelper;
+import org.jboss.wsf.stack.cxf.client.Constants;
 
 /**
  * 
@@ -66,6 +67,35 @@ class CXFStackConfig implements StackConfig
       finally
       {
          setContextClassLoader(orig);
+      }
+
+      // [JBWS-4521] CXF 4.1.8+ blocks decoupled WS-Addressing destinations by default (SSRF hardening).
+      // Re-enable for backward compatibility via the JBossWS-CXF property, defaulting to true.
+      // External override via -D flag or WildFly <system-properties> is respected at either level.
+      if (System.getSecurityManager() == null)
+      {
+         configureDecoupledAddressing();
+      }
+      else
+      {
+         AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            public Void run()
+            {
+               configureDecoupledAddressing();
+               return null;
+            }
+         });
+      }
+   }
+
+   private static void configureDecoupledAddressing()
+   {
+      if (System.getProperty("org.apache.cxf.ws.addressing.decoupled.enabled") == null) {
+         String decoupledEnabled = System.getProperty(Constants.JBWS_CXF_DECOUPLED_ENDPOINT_ENABLED);
+         if (decoupledEnabled == null) {
+            decoupledEnabled = "true";
+         }
+         System.setProperty("org.apache.cxf.ws.addressing.decoupled.enabled", decoupledEnabled);
       }
    }
 

--- a/modules/server/src/main/java/org/jboss/wsf/stack/cxf/configuration/BusHolder.java
+++ b/modules/server/src/main/java/org/jboss/wsf/stack/cxf/configuration/BusHolder.java
@@ -204,6 +204,9 @@ public class BusHolder
       //[JBWS-3135] enable decoupled faultTo. This is an optional feature in cxf and we need this to be default to make it same behavior with native stack
       bus.setProperty("org.apache.cxf.ws.addressing.decoupled_fault_support", true);
 
+      //[JBWS-4521] CXF 4.1.8+ decoupled WS-Addressing destination enablement is handled as a
+      // JVM-wide system property in CXFStackConfig's constructor (one-time JVM-level init)
+
       //[JBWS-4458] Use DelayedCachedOutputStreamCleaner.SingleTimerDelayedCleaner strategy to prevent threads leaking
       bus.setProperty(CachedConstants.CLEANER_STRATEGY_BUS_PROP, "single-timer");
 

--- a/modules/testsuite/cxf-tests/src/test/etc/arquillian.xml
+++ b/modules/testsuite/cxf-tests/src/test/etc/arquillian.xml
@@ -34,6 +34,22 @@
             <property name="startupTimeoutInSeconds">${startupTimeoutInSeconds:60}</property>
         </configuration>
     </container>
+    <container qualifier="jboss-decoupled-disabled" mode="manual">
+        <configuration>
+            <property name="jbossHome">${jboss.home}</property>
+            <property name="javaVmArguments">-server -Xms64m -Xmx512m -Djboss.socket.binding.port-offset=${port-offset.cxf-tests.jboss-decoupled-disabled} ${modular.jdk.args} ${additionalJvmArgs} -Dorg.jboss.ws.cxf.decoupledEndpointEnabled=false</property>
+            <property name="serverConfig">jbws-testsuite-default.xml</property>
+            <property name="outputToConsole">true</property>
+            <property name="allowConnectingToRunningServer">true</property>
+            <property name="managementAddress">${jboss.bind.address:localhost}</property>
+            <property name="jbossArguments">${jbossArguments}</property>
+            <property name="managementPort">${cxf-tests.jboss-decoupled-disabled_9990}</property>
+            <!-- AS7-4070 -->
+            <property name="waitForPorts">${cxf-tests.jboss-decoupled-disabled_8787} ${cxf-tests.jboss-decoupled-disabled_9990}</property>
+            <property name="waitForPortsTimeoutInSeconds">45</property>
+            <property name="startupTimeoutInSeconds">${startupTimeoutInSeconds:60}</property>
+        </configuration>
+    </container>
     <container qualifier="ssl-mutual-auth" mode="manual">
         <configuration>
             <property name="jbossHome">${jboss.home}</property>

--- a/modules/testsuite/cxf-tests/src/test/etc/container.properties
+++ b/modules/testsuite/cxf-tests/src/test/etc/container.properties
@@ -5,6 +5,7 @@ port-offset.cxf-tests.ssl-mutual-auth=@port-offset.cxf-tests.ssl-mutual-auth@
 port-offset.cxf-tests.default-config-tests=@port-offset.cxf-tests.default-config-tests@
 port-offset.cxf-tests.jms=@port-offset.cxf-tests.jms@
 port-offset.cxf-tests.jboss-sysprop=@port-offset.cxf-tests.jboss-sysprop@
+port-offset.cxf-tests.jboss-decoupled-disabled=@port-offset.cxf-tests.jboss-decoupled-disabled@
 port-offset.shared-tests.jboss=@port-offset.shared-tests.jboss@
 port-offset.shared-tests.default-config-tests=@port-offset.shared-tests.default-config-tests@
 port-offset.cxf-spring-tests.jboss=@port-offset.cxf-spring-tests.jboss@

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws3516/JBWS3516NegativeTestCase.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws3516/JBWS3516NegativeTestCase.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.test.ws.jaxws.cxf.jbws3516;
+
+import java.io.File;
+import java.net.URL;
+
+import javax.xml.namespace.QName;
+import jakarta.xml.ws.BindingProvider;
+import jakarta.xml.ws.Service;
+import jakarta.xml.ws.soap.AddressingFeature;
+import jakarta.xml.ws.soap.SOAPFaultException;
+
+import org.apache.cxf.ws.addressing.AddressingProperties;
+import org.apache.cxf.ws.addressing.AttributedURIType;
+import org.apache.cxf.ws.addressing.EndpointReferenceType;
+import org.apache.cxf.ws.addressing.JAXWSAConstants;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Filter;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.wsf.test.JBossWSTest;
+import org.jboss.wsf.test.JBossWSTestHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Verifies that decoupled WS-Addressing FaultTo/ReplyTo is rejected when
+ * {@code org.jboss.ws.cxf.decoupledEndpointEnabled} is set to {@code false}.
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JBWS3516NegativeTestCase extends JBossWSTest
+{
+   private static final String CONTAINER_NAME = "jboss-decoupled-disabled";
+   private static final String DEPLOYMENT_NAME = "jaxws-cxf-jbws3516-negative";
+
+   @ArquillianResource
+   private ContainerController containerController;
+
+   @ArquillianResource
+   private Deployer deployer;
+
+   @Deployment(name = DEPLOYMENT_NAME, managed = false, testable = false)
+   @TargetsContainer(CONTAINER_NAME)
+   public static WebArchive createDeployment()
+   {
+      WebArchive archive = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME + ".war");
+      archive.setManifest(new StringAsset("Manifest-Version: 1.0\n"
+                  + "Dependencies: org.apache.cxf.impl\n"))
+            .addPackages(false, new Filter<ArchivePath>() {
+               @Override
+               public boolean include(ArchivePath object)
+               {
+                  return !object.get().contains("TestCase");
+               }}, "org.jboss.test.ws.jaxws.cxf.jbws3516")
+            .addAsWebInfResource(new File(JBossWSTestHelper.getTestResourcesDir() + "/jaxws/cxf/jbws3516/WEB-INF/wsdl/hello_world.wsdl"), "wsdl/hello_world.wsdl")
+            .setWebXML(new File(JBossWSTestHelper.getTestResourcesDir() + "/jaxws/cxf/jbws3516/WEB-INF/web.xml"));
+      return archive;
+   }
+
+   @BeforeEach
+   public void startContainer()
+   {
+      if (!containerController.isStarted(CONTAINER_NAME))
+      {
+         containerController.start(CONTAINER_NAME);
+      }
+      deployer.deploy(DEPLOYMENT_NAME);
+   }
+
+   @AfterEach
+   public void stopContainer()
+   {
+      try
+      {
+         deployer.undeploy(DEPLOYMENT_NAME);
+      }
+      catch (Exception e)
+      {
+         // ignore
+      }
+      if (containerController.isStarted(CONTAINER_NAME))
+      {
+         containerController.stop(CONTAINER_NAME);
+      }
+   }
+
+   @Test
+   @RunAsClient
+   public void testDecoupledFaultToRejected() throws Exception
+   {
+      final int port = getServerPort("cxf-tests", CONTAINER_NAME);
+      final String serverHost = getServerHost();
+      final URL baseURL = new URL("http://" + serverHost + ":" + port + "/" + DEPLOYMENT_NAME + "/");
+      final URL wsdlURL = new URL(baseURL + "helloworld?wsdl");
+      final QName qname = new QName("http://jboss.org/hello_world", "SOAPService");
+      final Service service = Service.create(wsdlURL, qname);
+      final Greeter greeter = service.getPort(Greeter.class, new AddressingFeature());
+
+      AddressingProperties addrProperties = new AddressingProperties();
+
+      EndpointReferenceType faultTo = new EndpointReferenceType();
+      AttributedURIType epr = new AttributedURIType();
+      epr.setValue("http://" + serverHost + ":" + port + "/" + DEPLOYMENT_NAME + "/target/faultTo");
+      faultTo.setAddress(epr);
+      addrProperties.setFaultTo(faultTo);
+
+      EndpointReferenceType replyTo = new EndpointReferenceType();
+      AttributedURIType replyToURI = new AttributedURIType();
+      replyToURI.setValue("http://" + serverHost + ":" + port + "/" + DEPLOYMENT_NAME + "/target/replyTo");
+      replyTo.setAddress(replyToURI);
+      addrProperties.setReplyTo(replyTo);
+
+      BindingProvider provider = (BindingProvider) greeter;
+      provider.getRequestContext().put(JAXWSAConstants.CLIENT_ADDRESSING_PROPERTIES, addrProperties);
+
+      SOAPFaultException ex = assertThrows(SOAPFaultException.class, () -> greeter.sayHi("hello"));
+      assertTrue(ex.getMessage().contains("Unexpected EOF in prolog"),
+            "Expected 'Unexpected EOF in prolog' SOAPFault but got: " + ex.getMessage());
+   }
+}

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws3773/JBWS3773NegativeTestCase.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/cxf/jbws3773/JBWS3773NegativeTestCase.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.test.ws.jaxws.cxf.jbws3773;
+
+import java.net.URL;
+
+import javax.xml.namespace.QName;
+import jakarta.xml.ws.BindingProvider;
+import jakarta.xml.ws.Service;
+import jakarta.xml.ws.soap.AddressingFeature;
+import jakarta.xml.ws.soap.SOAPFaultException;
+
+import org.apache.cxf.ws.addressing.AddressingProperties;
+import org.apache.cxf.ws.addressing.AttributedURIType;
+import org.apache.cxf.ws.addressing.EndpointReferenceType;
+import org.apache.cxf.ws.addressing.JAXWSAConstants;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.wsf.test.JBossWSTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Verifies that decoupled WS-Addressing ReplyTo is rejected when
+ * {@code org.jboss.ws.cxf.decoupledEndpointEnabled} is set to {@code false}.
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JBWS3773NegativeTestCase extends JBossWSTest
+{
+   private static final String CONTAINER_NAME = "jboss-decoupled-disabled";
+   private static final String DEPLOYMENT_NAME = "jaxws-cxf-jbws3773-negative";
+
+   @ArquillianResource
+   private ContainerController containerController;
+
+   @ArquillianResource
+   private Deployer deployer;
+
+   @Deployment(name = DEPLOYMENT_NAME, managed = false, testable = false)
+   @TargetsContainer(CONTAINER_NAME)
+   public static WebArchive createDeployment()
+   {
+      return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME + ".war")
+            .addManifest()
+            .addClass(Greeter.class)
+            .addClass(GreeterImpl.class)
+            .addClass(TargetServlet.class);
+   }
+
+   @BeforeEach
+   public void startContainer()
+   {
+      if (!containerController.isStarted(CONTAINER_NAME))
+      {
+         containerController.start(CONTAINER_NAME);
+      }
+      deployer.deploy(DEPLOYMENT_NAME);
+   }
+
+   @AfterEach
+   public void stopContainer()
+   {
+      try
+      {
+         deployer.undeploy(DEPLOYMENT_NAME);
+      }
+      catch (Exception e)
+      {
+         // ignore
+      }
+      if (containerController.isStarted(CONTAINER_NAME))
+      {
+         containerController.stop(CONTAINER_NAME);
+      }
+   }
+
+   @Test
+   @RunAsClient
+   public void testDecoupledReplyToRejected() throws Exception
+   {
+      final int port = getServerPort("cxf-tests", CONTAINER_NAME);
+      final URL baseURL = new URL("http://" + getServerHost() + ":" + port + "/" + DEPLOYMENT_NAME + "/");
+      final URL wsdlURL = new URL(baseURL + "SOAPService?wsdl");
+      final QName qname = new QName("http://jboss.org/hello_world", "SOAPService");
+      final Service service = Service.create(wsdlURL, qname);
+      final Greeter greeter = service.getPort(Greeter.class, new AddressingFeature());
+
+      AddressingProperties addrProperties = new AddressingProperties();
+      EndpointReferenceType replyTo = new EndpointReferenceType();
+      AttributedURIType replyToURI = new AttributedURIType();
+      replyToURI.setValue(baseURL + "target/replyTo");
+      replyTo.setAddress(replyToURI);
+      addrProperties.setReplyTo(replyTo);
+
+      BindingProvider provider = (BindingProvider) greeter;
+      provider.getRequestContext().put(JAXWSAConstants.CLIENT_ADDRESSING_PROPERTIES, addrProperties);
+
+      SOAPFaultException ex = assertThrows(SOAPFaultException.class, () -> greeter.sayHi("Foo"));
+      assertTrue(ex.getMessage().contains("is not permitted by this server"),
+            "Expected 'not permitted' SOAPFault but got: " + ex.getMessage());
+   }
+}

--- a/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/samples/wsa/AddressingNegativeTestCase.java
+++ b/modules/testsuite/cxf-tests/src/test/java/org/jboss/test/ws/jaxws/samples/wsa/AddressingNegativeTestCase.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jboss.test.ws.jaxws.samples.wsa;
+
+import java.io.File;
+import java.net.URL;
+
+import javax.xml.namespace.QName;
+import jakarta.xml.ws.Service;
+import jakarta.xml.ws.soap.SOAPFaultException;
+
+import org.apache.cxf.Bus;
+import org.apache.cxf.BusFactory;
+import org.apache.cxf.endpoint.Client;
+import org.apache.cxf.frontend.ClientProxy;
+import org.apache.cxf.transport.http.HTTPConduit;
+import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.wsf.stack.cxf.client.UseThreadBusFeature;
+import org.jboss.wsf.test.JBossWSTest;
+import org.jboss.wsf.test.JBossWSTestHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Verifies that client-side decoupled endpoint is rejected by the server when
+ * {@code org.jboss.ws.cxf.decoupledEndpointEnabled} is set to {@code false}.
+ */
+@ExtendWith(ArquillianExtension.class)
+public final class AddressingNegativeTestCase extends JBossWSTest
+{
+   private static final String CONTAINER_NAME = "jboss-decoupled-disabled";
+   private static final String DEPLOYMENT_NAME = "jaxws-samples-wsa-negative";
+
+   @ArquillianResource
+   private ContainerController containerController;
+
+   @ArquillianResource
+   private Deployer deployer;
+
+   @Deployment(name = DEPLOYMENT_NAME, managed = false, testable = false)
+   @TargetsContainer(CONTAINER_NAME)
+   public static WebArchive createDeployment()
+   {
+      return ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME + ".war")
+            .addManifest()
+            .addClass(ServiceIface.class)
+            .addClass(ServiceImpl.class)
+            .addClass(org.jboss.test.ws.jaxws.samples.wsa.jaxws.SayHello.class)
+            .addClass(org.jboss.test.ws.jaxws.samples.wsa.jaxws.SayHelloResponse.class)
+            .setWebXML(new File(JBossWSTestHelper.getTestResourcesDir() + "/jaxws/samples/wsa/WEB-INF/web.xml"));
+   }
+
+   @BeforeEach
+   public void startContainer()
+   {
+      if (!containerController.isStarted(CONTAINER_NAME))
+      {
+         containerController.start(CONTAINER_NAME);
+      }
+      deployer.deploy(DEPLOYMENT_NAME);
+   }
+
+   @AfterEach
+   public void stopContainer()
+   {
+      try
+      {
+         deployer.undeploy(DEPLOYMENT_NAME);
+      }
+      catch (Exception e)
+      {
+         // ignore
+      }
+      if (containerController.isStarted(CONTAINER_NAME))
+      {
+         containerController.stop(CONTAINER_NAME);
+      }
+   }
+
+   @Test
+   @RunAsClient
+   public void testDecoupledEndpointRejected() throws Exception
+   {
+      final int port = getServerPort("cxf-tests", CONTAINER_NAME);
+      final Bus bus = BusFactory.newInstance().createBus();
+      BusFactory.setThreadDefaultBus(bus);
+      try
+      {
+         QName serviceName = new QName("http://www.jboss.org/jbossws/ws-extensions/wsaddressing", "AddressingService");
+         URL wsdlURL = new URL("http://" + getServerHost() + ":" + port + "/" + DEPLOYMENT_NAME + "/AddressingService?wsdl");
+         Service service = Service.create(wsdlURL, serviceName, new UseThreadBusFeature());
+         ServiceIface proxy = (ServiceIface) service.getPort(ServiceIface.class);
+
+         Client client = ClientProxy.getClient(proxy);
+         HTTPConduit conduit = (HTTPConduit) client.getConduit();
+         HTTPClientPolicy policy = conduit.getClient();
+         policy.setConnectionTimeout(5000);
+         policy.setReceiveTimeout(10000);
+         policy.setDecoupledEndpoint("http://" + getServerHost() + ":18181/jaxws-samples-wsa-negative/decoupled-endpoint");
+
+         SOAPFaultException ex = assertThrows(SOAPFaultException.class, () -> proxy.sayHello("Sleepy"));
+         assertTrue(ex.getMessage().contains("is not permitted by this server"),
+               "Expected 'not permitted' SOAPFault but got: " + ex.getMessage());
+      }
+      finally
+      {
+         bus.shutdown(true);
+      }
+   }
+}

--- a/modules/testsuite/pom.xml
+++ b/modules/testsuite/pom.xml
@@ -29,6 +29,7 @@
     <port-offset.cxf-tests.default-config-tests>10000</port-offset.cxf-tests.default-config-tests>
     <port-offset.cxf-tests.jms>35000</port-offset.cxf-tests.jms>
     <port-offset.cxf-tests.jboss-sysprop>40000</port-offset.cxf-tests.jboss-sysprop>
+    <port-offset.cxf-tests.jboss-decoupled-disabled>45000</port-offset.cxf-tests.jboss-decoupled-disabled>
     <port-offset.shared-tests.jboss>15000</port-offset.shared-tests.jboss>
     <port-offset.shared-tests.default-config-tests>20000</port-offset.shared-tests.default-config-tests>
     <port-offset.shared-tests.address-rewrite>25000</port-offset.shared-tests.address-rewrite>
@@ -50,6 +51,9 @@
     <cxf-tests.jms_8787>43787</cxf-tests.jms_8787>
     <cxf-tests.jboss-sysprop_9990>49990</cxf-tests.jboss-sysprop_9990>
     <cxf-tests.jboss-sysprop_8787>48787</cxf-tests.jboss-sysprop_8787>
+    <cxf-tests.jboss-decoupled-disabled_8080>53080</cxf-tests.jboss-decoupled-disabled_8080>
+    <cxf-tests.jboss-decoupled-disabled_9990>54990</cxf-tests.jboss-decoupled-disabled_9990>
+    <cxf-tests.jboss-decoupled-disabled_8787>53787</cxf-tests.jboss-decoupled-disabled_8787>
     <shared-tests.jboss_8080>23080</shared-tests.jboss_8080>
     <shared-tests.jboss_9990>24990</shared-tests.jboss_9990>
     <shared-tests.jboss_8787>23787</shared-tests.jboss_8787>

--- a/pom.xml
+++ b/pom.xml
@@ -72,9 +72,9 @@
     <commons.lang3.version>3.18.0</commons.lang3.version>
     <commons.logging.version>1.2</commons.logging.version>
     <commons.validator.version>1.9.0</commons.validator.version>
-    <cxf.version>4.1.6</cxf.version>
-    <cxf.asm.version>9.9.1</cxf.asm.version>                              <!-- See https://github.com/apache/cxf/blob/cxf-4.1.6/parent/pom.xml#L60 -->
-    <cxf.xjcplugins.version>4.1.3</cxf.xjcplugins.version>                <!-- See https://github.com/apache/cxf/blob/cxf-4.1.6/pom.xml#L44 -->
+    <cxf.version>4.1.8</cxf.version>
+    <cxf.asm.version>9.10.1</cxf.asm.version>                             <!-- See https://github.com/apache/cxf/blob/cxf-4.1.8/parent/pom.xml#L61 -->
+    <cxf.xjcplugins.version>4.1.3</cxf.xjcplugins.version>                <!-- See https://github.com/apache/cxf/blob/cxf-4.1.8/pom.xml#L44 -->
     <derby.version>10.15.2.0</derby.version>
     <easymock.version>3.2</easymock.version>
     <eclipse.plugin.version>1.0.0</eclipse.plugin.version>
@@ -88,14 +88,14 @@
     <jakarta.enterprise.cdi.api.version>4.1.0</jakarta.enterprise.cdi.api.version>
     <jakarta.inject.api.version>2.0.1</jakarta.inject.api.version>
     <jakarta.interceptor.api.version>2.2.0</jakarta.interceptor.api.version>
-    <jakarta.jms.api.version>3.1.0</jakarta.jms.api.version>              <!-- See https://github.com/apache/cxf/blob/cxf-4.1.6/parent/pom.xml#L145 -->
+    <jakarta.jms.api.version>3.1.0</jakarta.jms.api.version>              <!-- See https://github.com/apache/cxf/blob/cxf-4.1.8/parent/pom.xml#L146 -->
     <jakarta.json.api.version>2.1.3</jakarta.json.api.version>
     <jakarta.mail.version>2.1.5</jakarta.mail.version>
     <jakarta.servlet.api.version>6.1.0</jakarta.servlet.api.version>
-    <jakarta.xml.bind.api.version>4.0.5</jakarta.xml.bind.api.version>    <!-- See https://github.com/apache/cxf/blob/cxf-4.1.6/parent/pom.xml#L155 -->
-    <jakarta.xml.soap.api.version>3.0.2</jakarta.xml.soap.api.version>    <!-- See https://github.com/apache/cxf/blob/cxf-4.1.6/parent/pom.xml#L143 -->
-    <jakarta.xml.ws.api.version>4.0.3</jakarta.xml.ws.api.version>        <!-- See https://github.com/apache/cxf/blob/cxf-4.1.6/parent/pom.xml#L144 -->
-    <jaxb.impl.version>4.0.8</jaxb.impl.version>                          <!-- See https://github.com/apache/cxf/blob/cxf-4.1.6/parent/pom.xml#L154 -->
+    <jakarta.xml.bind.api.version>4.0.5</jakarta.xml.bind.api.version>    <!-- See https://github.com/apache/cxf/blob/cxf-4.1.8/parent/pom.xml#L156 -->
+    <jakarta.xml.soap.api.version>3.0.2</jakarta.xml.soap.api.version>    <!-- See https://github.com/apache/cxf/blob/cxf-4.1.8/parent/pom.xml#L144 -->
+    <jakarta.xml.ws.api.version>4.0.3</jakarta.xml.ws.api.version>        <!-- See https://github.com/apache/cxf/blob/cxf-4.1.8/parent/pom.xml#L145 -->
+    <jaxb.impl.version>4.0.9</jaxb.impl.version>                          <!-- See https://github.com/apache/cxf/blob/cxf-4.1.8/parent/pom.xml#L155 -->
     <jboss.ejb.client.version>5.0.8.Final</jboss.ejb.client.version>
     <jboss.ejb3.ext.api.version>2.4.0.Final</jboss.ejb3.ext.api.version>
     <jboss.jaxbintros.version>2.1.0.Final</jboss.jaxbintros.version>
@@ -120,7 +120,7 @@
     <neethi.version>3.2.2</neethi.version>
     <opensaml.version>4.3.2</opensaml.version>
     <saaj.api.version>1.0.0.Final</saaj.api.version>
-    <saaj.impl.version>3.0.5</saaj.impl.version>                          <!-- See https://github.com/apache/cxf/blob/cxf-4.1.6/parent/pom.xml#L208 -->
+    <saaj.impl.version>3.0.6</saaj.impl.version>                          <!-- See https://github.com/apache/cxf/blob/cxf-4.1.8/parent/pom.xml#L209 -->
     <shrinkwrap.version>1.2.6</shrinkwrap.version>
     <testcontainer.version>1.21.0</testcontainer.version>
     <velocity.version>2.4.1</velocity.version>
@@ -141,7 +141,7 @@
       TODO in https://redhat.atlassian.net/browse/JBWS-4469
     -->
     <wss4j.version>3.0.5</wss4j.version>
-    <wstx.version>7.1.1</wstx.version>                                    <!-- See https://github.com/apache/cxf/blob/cxf-4.1.6/parent/pom.xml#L236 -->
+    <wstx.version>7.2.1</wstx.version>                                    <!-- See https://github.com/apache/cxf/blob/cxf-4.1.8/parent/pom.xml#L237 -->
     <xmlsec.version>3.0.6</xmlsec.version>
     <modular.jdk.args />
     <modular.jdk.props />


### PR DESCRIPTION
Upgrade Apache CXF from 4.1.6 to 4.1.8, see https://redhat.atlassian.net/browse/JBWS-4521.

Apache CXF 4.1.8 includes a security improvement to block decoupled WS-Addressing destinations by default (SSRF hardening), see https://github.com/apache/cxf/pull/3279.

This PR includes changes to drive such configuration and to enable decoupled WS-Addressing destinations by default, in order to preserve backward compatibility with WildFly, while keeping the possibility to leverage the security improvement.

As a result, the server behavior won't change with respect to the Web services features, but users can opt-out and leverage the new CXF functionality and set the property explicitly to disable decoupled WS-Addressing destinations.

@ropalka I'd appreciate your feedback here, specifically about the fact that I introduced a JBossWS-CXF property to shadow the new APache CXF property. 

CC @jamezp, @bstansberry. 